### PR TITLE
Deployment init

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,257 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*.*.*'
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to deploy to staging (optional)'
+        required: false
+        type: string
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy_prod:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build image
+        run: |
+          docker build -t marketplace:prod-${{ github.sha }} .
+          docker save marketplace:prod-${{ github.sha }} -o /tmp/marketplace-prod.tar
+
+      - name: Copy image to droplet
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.DO_SSH_HOST }}
+          username: ${{ secrets.DO_SSH_USER }}
+          key: ${{ secrets.DO_SSH_KEY }}
+          port: ${{ secrets.DO_SSH_PORT || 22 }}
+          source: /tmp/marketplace-prod.tar
+          target: /tmp
+
+      - name: Copy deploy script to droplet
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.DO_SSH_HOST }}
+          username: ${{ secrets.DO_SSH_USER }}
+          key: ${{ secrets.DO_SSH_KEY }}
+          port: ${{ secrets.DO_SSH_PORT || 22 }}
+          source: scripts/deploy/remote_deploy.sh
+          target: /tmp
+
+      - name: Deploy prod on droplet
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.DO_SSH_HOST }}
+          username: ${{ secrets.DO_SSH_USER }}
+          key: ${{ secrets.DO_SSH_KEY }}
+          port: ${{ secrets.DO_SSH_PORT || 22 }}
+          script: |
+            if [[ -f /tmp/remote_deploy.sh ]]; then
+              DEPLOY_SCRIPT=/tmp/remote_deploy.sh
+            else
+              DEPLOY_SCRIPT=/tmp/scripts/deploy/remote_deploy.sh
+            fi
+            chmod +x "${DEPLOY_SCRIPT}"
+            IMAGE_TAG=marketplace:prod-${{ github.sha }} \
+            IMAGE_TAR=/tmp/marketplace-prod.tar \
+            APP_NAME=marketplace \
+            CONTAINER_NAME=marketplace \
+            APP_PORT=8080 \
+            APP_ENV_FILE=/etc/marketplace/prod.env \
+            "${DEPLOY_SCRIPT}"
+
+  deploy_staging_main:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build image
+        run: |
+          docker build -t marketplace:staging-${{ github.sha }} .
+          docker save marketplace:staging-${{ github.sha }} -o /tmp/marketplace-staging.tar
+
+      - name: Copy image to droplet
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.DO_SSH_HOST }}
+          username: ${{ secrets.DO_SSH_USER }}
+          key: ${{ secrets.DO_SSH_KEY }}
+          port: ${{ secrets.DO_SSH_PORT || 22 }}
+          source: /tmp/marketplace-staging.tar
+          target: /tmp
+
+      - name: Copy deploy script to droplet
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.DO_SSH_HOST }}
+          username: ${{ secrets.DO_SSH_USER }}
+          key: ${{ secrets.DO_SSH_KEY }}
+          port: ${{ secrets.DO_SSH_PORT || 22 }}
+          source: scripts/deploy/remote_deploy.sh
+          target: /tmp
+
+      - name: Deploy staging (main) on droplet
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.DO_SSH_HOST }}
+          username: ${{ secrets.DO_SSH_USER }}
+          key: ${{ secrets.DO_SSH_KEY }}
+          port: ${{ secrets.DO_SSH_PORT || 22 }}
+          script: |
+            if [[ -f /tmp/remote_deploy.sh ]]; then
+              DEPLOY_SCRIPT=/tmp/remote_deploy.sh
+            else
+              DEPLOY_SCRIPT=/tmp/scripts/deploy/remote_deploy.sh
+            fi
+            chmod +x "${DEPLOY_SCRIPT}"
+            IMAGE_TAG=marketplace:staging-${{ github.sha }} \
+            IMAGE_TAR=/tmp/marketplace-staging.tar \
+            APP_NAME=marketplace-staging \
+            CONTAINER_NAME=marketplace-staging \
+            APP_PORT=8081 \
+            APP_ENV_FILE=/etc/marketplace/staging.env \
+            "${DEPLOY_SCRIPT}"
+
+  deploy_staging_pr:
+    if: github.event_name == 'workflow_dispatch' && inputs.pr_number != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch PR details and verify approval
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = Number(core.getInput('pr_number'));
+            const { owner, repo } = context.repo;
+            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+            if (pr.state !== 'open') {
+              core.setFailed(`PR #${prNumber} is not open`);
+              return;
+            }
+            if (pr.head.repo.full_name !== `${owner}/${repo}`) {
+              core.setFailed(`PR #${prNumber} is from a fork; refusing to deploy`);
+              return;
+            }
+            const { data: reviews } = await github.rest.pulls.listReviews({ owner, repo, pull_number: prNumber });
+            const hasApproval = reviews.some((review) => review.state === 'APPROVED');
+            if (!hasApproval) {
+              core.setFailed(`PR #${prNumber} has no approved review`);
+              return;
+            }
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ inputs.pr_number }}/head
+
+      - name: Build image
+        run: |
+          docker build -t marketplace:pr-${{ inputs.pr_number }}-${{ github.sha }} .
+          docker save marketplace:pr-${{ inputs.pr_number }}-${{ github.sha }} -o /tmp/marketplace-pr-${{ inputs.pr_number }}.tar
+
+      - name: Copy image to droplet
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.DO_SSH_HOST }}
+          username: ${{ secrets.DO_SSH_USER }}
+          key: ${{ secrets.DO_SSH_KEY }}
+          port: ${{ secrets.DO_SSH_PORT || 22 }}
+          source: /tmp/marketplace-pr-${{ inputs.pr_number }}.tar
+          target: /tmp
+
+      - name: Copy deploy script to droplet
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.DO_SSH_HOST }}
+          username: ${{ secrets.DO_SSH_USER }}
+          key: ${{ secrets.DO_SSH_KEY }}
+          port: ${{ secrets.DO_SSH_PORT || 22 }}
+          source: scripts/deploy/remote_deploy.sh
+          target: /tmp
+
+      - name: Deploy staging (PR) on droplet
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.DO_SSH_HOST }}
+          username: ${{ secrets.DO_SSH_USER }}
+          key: ${{ secrets.DO_SSH_KEY }}
+          port: ${{ secrets.DO_SSH_PORT || 22 }}
+          script: |
+            if [[ -f /tmp/remote_deploy.sh ]]; then
+              DEPLOY_SCRIPT=/tmp/remote_deploy.sh
+            else
+              DEPLOY_SCRIPT=/tmp/scripts/deploy/remote_deploy.sh
+            fi
+            chmod +x "${DEPLOY_SCRIPT}"
+            IMAGE_TAG=marketplace:pr-${{ inputs.pr_number }}-${{ github.sha }} \
+            IMAGE_TAR=/tmp/marketplace-pr-${{ inputs.pr_number }}.tar \
+            APP_NAME=marketplace-staging \
+            CONTAINER_NAME=marketplace-staging \
+            APP_PORT=8081 \
+            APP_ENV_FILE=/etc/marketplace/staging.env \
+            "${DEPLOY_SCRIPT}"
+
+  deploy_tag_supabase:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate tag format
+        run: |
+          if [[ ! "${GITHUB_REF_NAME}" =~ ^[0-9]+\.[0-9]+\..+$ ]]; then
+            echo "Tag must be MAJOR.MINOR.<anything> with numeric MAJOR and MINOR"
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Supabase functions and migrations
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
+        run: |
+          cd supabase
+          supabase link --project-ref "${SUPABASE_PROJECT_ID}"
+          supabase functions deploy fetch_package
+          supabase db push
+
+  deploy_staging_supabase:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Supabase functions and migrations (staging)
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_STAGING_ACCESS_TOKEN }}
+          SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_STAGING_PROJECT_ID }}
+        run: |
+          cd supabase
+          supabase link --project-ref "${SUPABASE_PROJECT_ID}"
+          supabase functions deploy fetch_package
+          supabase db push

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ The Supabase CLI scripts are still available for cloud projects:
 - Build: `docker build -t mautic-marketplace .`
 - Run: `docker compose up -d`
 
+## Deployment
+- DigitalOcean + GitHub Actions: `docs/deploy-digitalocean.md`
+
 ## Reference Links
 - Existing marketplace UI in Mautic admin: https://github.com/mautic/mautic/tree/7.x/app/bundles/MarketplaceBundle
 - Supabase middleware integration PR: https://github.com/mautic/mautic/pull/15500

--- a/docs/deploy-digitalocean.md
+++ b/docs/deploy-digitalocean.md
@@ -1,0 +1,173 @@
+# Deploy to a DigitalOcean Droplet via GitHub Actions (Supabase + Auth0)
+
+Deploy the Mautic Marketplace (Supabase + Auth0) to a DigitalOcean droplet via GitHub Actions.
+
+## Deployment workflow
+1. GitHub Actions builds a Docker image.
+2. The image is transferred to the droplet with `docker save` → `scp` → `docker load`.
+3. The droplet deploy script runs the container and manages Nginx + Certbot if domains are configured.
+4. Supabase functions/migrations run **only** on tag builds.
+
+## Implementation files
+- GitHub Actions workflow: `.github/workflows/deploy.yml`
+- Droplet deploy script: `scripts/deploy/remote_deploy.sh`
+
+## Environment and secrets
+GitHub Actions secrets (only for deploy + Supabase CLI):
+- `DO_SSH_HOST`, `DO_SSH_USER`, `DO_SSH_KEY`, `DO_SSH_PORT` (optional)
+- `SUPABASE_ACCESS_TOKEN`, `SUPABASE_PROJECT_ID`
+- `SUPABASE_STAGING_ACCESS_TOKEN`, `SUPABASE_STAGING_PROJECT_ID`
+
+Droplet environment files (application config):
+- `/etc/marketplace/prod.env` (prod app env vars)
+- `/etc/marketplace/staging.env` (staging app env vars)
+
+Droplet host config:
+- Docker installed
+- Optional: `ufw` firewall and fail2ban
+- Nginx reverse proxy for HTTPS and routing
+
+### Where to get secrets
+**DigitalOcean (SSH access):**
+- Create an SSH key pair locally and add the **public** key to the droplet.
+- Store the **private** key in GitHub Actions as `DO_SSH_KEY`.
+- `DO_SSH_HOST` is the droplet public IP or hostname.
+- `DO_SSH_USER` is the SSH user (e.g., `root` or a dedicated deploy user).
+
+**Auth0:**
+- Get values from the Auth0 dashboard for your application and API.
+- Store client ID/secret and issuer/tenant URL in GitHub Actions.
+
+**Database / Symfony:**
+- `APP_SECRET` should be a long random string.
+- `DATABASE_URL` should point to your production database.
+
+**Supabase (hosted):**
+- Get the Supabase Project ID (Reference ID) from `Project Settings` > `General Settings`.
+- Copy API keys (`anon public`, `service_role`) from `Project Settings` > `API`.
+- Store `SUPABASE_URL`, `SUPABASE_ANON_KEY`, and `SUPABASE_SERVICE_ROLE_KEY` in the droplet env files (`/etc/marketplace/prod.env` or `/etc/marketplace/staging.env`).
+- Store a Supabase access token as `SUPABASE_ACCESS_TOKEN` in GitHub Actions **only** for running CLI migrations/functions.
+- Staging uses a **separate Supabase account/project**. Put its keys in `/etc/marketplace/staging.env`.
+
+## Supabase migrations & functions (tagged releases only)
+When a tag is created (e.g., `1.2.release`), the workflow runs:
+- `supabase link --project-ref <PROJECT_ID>`
+- `supabase functions deploy fetch_package`
+- `supabase db push`
+
+These steps run only on `refs/tags/*`.
+
+## Staging Supabase sync (main branch)
+On every push to `main`, the workflow deploys Supabase functions/migrations to the **staging** Supabase project using:
+- `SUPABASE_STAGING_ACCESS_TOKEN`
+- `SUPABASE_STAGING_PROJECT_ID`
+
+## Droplet setup (one-time)
+### Create the droplet
+- **OS:** Ubuntu 22.04 LTS
+- **Size:** 1 vCPU / 1–2 GB RAM (start with 1 GB)
+- **Network:** public IPv4
+- **SSH:** add your public key
+- **DNS:** create A records pointing to the droplet public IPv4:
+  - `marketplace.mautic.org` → `<droplet-ip>`
+  - `marketplace-staging.mautic.org` → `<droplet-ip>`
+
+### Install required packages
+```bash
+ssh root@<droplet-ip>
+
+apt-get update
+apt-get install -y docker.io nginx certbot python3-certbot-nginx
+systemctl enable --now docker nginx
+```
+
+### Droplet environment
+Create `/etc/marketplace/deploy.env` (used by the deploy script):
+```bash
+cat > /etc/marketplace/deploy.env <<'EOF'
+APP_DOMAIN=marketplace.mautic.org
+APP_DOMAIN_PORT=8080
+STAGING_DOMAIN=marketplace-staging.mautic.org
+STAGING_DOMAIN_PORT=8081
+LETSENCRYPT_EMAIL=ops@mautic.org
+EOF
+```
+
+Create `/etc/marketplace/prod.env` for production secrets:
+```bash
+cat > /etc/marketplace/prod.env <<'EOF'
+APP_ENV=prod
+APP_SECRET=change-me
+DATABASE_URL=postgresql://user:pass@host:5432/dbname
+SUPABASE_URL=https://your-prod-project.supabase.co
+SUPABASE_ANON_KEY=change-me
+SUPABASE_SERVICE_ROLE_KEY=change-me
+AUTH0_DOMAIN=your-tenant.us.auth0.com
+AUTH0_CLIENT_ID=change-me
+AUTH0_CLIENT_SECRET=change-me
+EOF
+```
+
+Create `/etc/marketplace/staging.env` for staging secrets:
+```bash
+cat > /etc/marketplace/staging.env <<'EOF'
+APP_ENV=prod
+APP_SECRET=change-me
+DATABASE_URL=postgresql://user:pass@host:5432/dbname
+SUPABASE_URL=https://your-staging-project.supabase.co
+SUPABASE_ANON_KEY=change-me
+SUPABASE_SERVICE_ROLE_KEY=change-me
+AUTH0_DOMAIN=your-tenant.us.auth0.com
+AUTH0_CLIENT_ID=change-me
+AUTH0_CLIENT_SECRET=change-me
+EOF
+```
+
+Ensure DNS A records exist for both `marketplace.mautic.org` and `marketplace-staging.mautic.org`.
+
+### Reverse proxy notes
+- The deploy script manages Nginx + Certbot when domains are set.
+- SSL setup runs only if a domain is provided via droplet environment (e.g., `APP_DOMAIN`).
+
+### Deploy user (recommended)
+Create a dedicated deploy user and allow the deploy script to run required commands.
+
+```bash
+# create user and add ssh key
+adduser --disabled-password --gecos "" deploy
+mkdir -p /home/deploy/.ssh
+chmod 700 /home/deploy/.ssh
+cat >> /home/deploy/.ssh/authorized_keys <<'EOF'
+<paste-public-key-here>
+EOF
+chmod 600 /home/deploy/.ssh/authorized_keys
+chown -R deploy:deploy /home/deploy/.ssh
+```
+
+Add passwordless sudo for the commands the deploy script uses:
+```bash
+cat > /etc/sudoers.d/marketplace-deploy <<'EOF'
+deploy ALL=(root) NOPASSWD: /usr/bin/docker, /usr/bin/systemctl, /usr/bin/apt-get, /usr/sbin/nginx, /usr/bin/certbot
+EOF
+chmod 440 /etc/sudoers.d/marketplace-deploy
+```
+
+If you use this deploy user, set `DO_SSH_USER=deploy`.
+
+## Release process (current)
+1. Merge to `main`.
+2. Create a tag `MAJOR.MINOR.<anything>` (e.g., `1.2.3` or `1.2.release`) when you want Supabase migrations/functions applied.
+3. GitHub Actions builds and saves the image, then copies it to the droplet.
+4. GitHub Actions deploys using `scripts/deploy/remote_deploy.sh`.
+5. GitHub Actions runs Supabase migrations + functions.
+
+## Staging and PR deploys
+- Main branch deploys to **prod** and **staging** on the shared droplet.
+- A manual workflow can deploy a specific PR to staging by PR number (`workflow_dispatch` input).
+- The workflow checks for at least one approved review and refuses PRs from forks.
+  Use GitHub Actions → **Deploy** → enter `pr_number`.
+- Staging responses include `X-Robots-Tag: noindex, nofollow, noarchive, nosnippet` to discourage indexing.
+
+## Rollback
+- Re-deploy the previous image tag on the droplet.
+- If a migration is non-reversible, document manual rollback steps.

--- a/scripts/deploy/remote_deploy.sh
+++ b/scripts/deploy/remote_deploy.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_NAME="${APP_NAME:-marketplace}"
+IMAGE_TAG="${IMAGE_TAG:-}"
+IMAGE_TAR="${IMAGE_TAR:-/tmp/${APP_NAME}.tar}"
+CONTAINER_NAME="${CONTAINER_NAME:-${APP_NAME}}"
+APP_PORT="${APP_PORT:-8080}"
+APP_ENV_FILE="${APP_ENV_FILE:-/etc/marketplace/app.env}"
+DEPLOY_ENV_FILE="${DEPLOY_ENV_FILE:-/etc/marketplace/deploy.env}"
+NGINX_SITE_NAME="${NGINX_SITE_NAME:-marketplace}"
+
+if [[ -f "${DEPLOY_ENV_FILE}" ]]; then
+  # shellcheck disable=SC1090
+  source "${DEPLOY_ENV_FILE}"
+fi
+
+if [[ -z "${IMAGE_TAG}" ]]; then
+  echo "IMAGE_TAG is required"
+  exit 1
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker is required on the droplet"
+  exit 1
+fi
+
+if [[ -f "${IMAGE_TAR}" ]]; then
+  docker load -i "${IMAGE_TAR}"
+fi
+
+if docker ps -a --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
+  docker rm -f "${CONTAINER_NAME}"
+fi
+
+if [[ -f "${APP_ENV_FILE}" ]]; then
+  APP_ENV_FILE_ARG=("--env-file" "${APP_ENV_FILE}")
+else
+  APP_ENV_FILE_ARG=()
+fi
+
+# Run the container on localhost and let Nginx handle public traffic.
+docker run -d \
+  --name "${CONTAINER_NAME}" \
+  --restart unless-stopped \
+  -p "127.0.0.1:${APP_PORT}:80" \
+  "${APP_ENV_FILE_ARG[@]}" \
+  "${IMAGE_TAG}"
+
+PROD_DOMAIN="${APP_DOMAIN:-}"
+PROD_PORT="${APP_DOMAIN_PORT:-8080}"
+STAGING_DOMAIN="${STAGING_DOMAIN:-}"
+STAGING_PORT="${STAGING_DOMAIN_PORT:-8081}"
+
+if [[ -n "${PROD_DOMAIN}" || -n "${STAGING_DOMAIN}" ]]; then
+  if ! command -v nginx >/dev/null 2>&1; then
+    apt-get update
+    apt-get install -y --no-install-recommends nginx
+  fi
+
+  if ! command -v certbot >/dev/null 2>&1; then
+    apt-get update
+    apt-get install -y --no-install-recommends certbot python3-certbot-nginx
+  fi
+
+  {
+    if [[ -n "${PROD_DOMAIN}" ]]; then
+      cat <<NGINX_CONF
+server {
+    listen 80;
+    server_name ${PROD_DOMAIN};
+
+    location / {
+        proxy_pass http://127.0.0.1:${PROD_PORT};
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+    }
+}
+NGINX_CONF
+    fi
+
+    if [[ -n "${STAGING_DOMAIN}" ]]; then
+      cat <<NGINX_CONF
+server {
+    listen 80;
+    server_name ${STAGING_DOMAIN};
+
+    location / {
+        proxy_pass http://127.0.0.1:${STAGING_PORT};
+        add_header X-Robots-Tag "noindex, nofollow, noarchive, nosnippet" always;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+    }
+}
+NGINX_CONF
+    fi
+  } > /etc/nginx/sites-available/${NGINX_SITE_NAME}.conf
+
+  ln -sf "/etc/nginx/sites-available/${NGINX_SITE_NAME}.conf" "/etc/nginx/sites-enabled/${NGINX_SITE_NAME}.conf"
+  rm -f /etc/nginx/sites-enabled/default
+
+  nginx -t
+  systemctl reload nginx
+
+  if [[ -n "${LETSENCRYPT_EMAIL:-}" ]]; then
+    if [[ -n "${PROD_DOMAIN}" ]]; then
+      if [[ ! -f "/etc/letsencrypt/live/${PROD_DOMAIN}/fullchain.pem" ]]; then
+        certbot --nginx \
+          --non-interactive \
+          --agree-tos \
+          --email "${LETSENCRYPT_EMAIL}" \
+          -d "${PROD_DOMAIN}"
+      fi
+    fi
+
+    if [[ -n "${STAGING_DOMAIN}" ]]; then
+      if [[ ! -f "/etc/letsencrypt/live/${STAGING_DOMAIN}/fullchain.pem" ]]; then
+        certbot --nginx \
+          --non-interactive \
+          --agree-tos \
+          --email "${LETSENCRYPT_EMAIL}" \
+          -d "${STAGING_DOMAIN}"
+      fi
+    fi
+  else
+    echo "LETSENCRYPT_EMAIL is not set; skipping certificate issuance"
+  fi
+else
+  echo "No domains set; skipping Nginx/Certbot setup"
+fi


### PR DESCRIPTION
## Summary
- Add GitHub Actions deploy workflow for prod, staging, tags, and manual PR deploys.
- Add droplet deploy script with Nginx+Certbot, prod/staging routing, and noindex headers for staging.
- Document end‑to‑end deployment, droplet setup, env files, and secrets.
- Link deployment docs from the README.

## Changes
- `.github/workflows/deploy.yml`
- `scripts/deploy/remote_deploy.sh`
- `docs/deploy-digitalocean.md`
- `README.md`

## Testing
- Not run (docs/workflow changes only).

## Notes
- Staging Supabase sync runs on `main` using `SUPABASE_STAGING_*` secrets.
- Manual PR deploy requires an approved review and PR from same repo (no forks).