### PR TITLE
Add mautic-resource, fetch resource and  filter data.

### DIFF
--- a/supabase/functions/fetch_package/index.ts
+++ b/supabase/functions/fetch_package/index.ts
@@ -140,6 +140,7 @@ async function main(req: Request) {
   const urls = [
     "https://packagist.org/packages/list.json?type=mautic-plugin",
     "https://packagist.org/packages/list.json?type=mautic-theme",
+    "https://packagist.org/packages/list.json?type=mautic-resource",
   ];
   for (const url of urls) {
     await fetchPackages(url, supabaseClient);

--- a/templates/marketplace/index.html.twig
+++ b/templates/marketplace/index.html.twig
@@ -26,6 +26,7 @@
                     <option value="">All types</option>
                     <option value="mautic-plugin" {% if filters.type == 'mautic-plugin' %}selected{% endif %}>Plugin</option>
                     <option value="mautic-theme" {% if filters.type == 'mautic-theme' %}selected{% endif %}>Theme</option>
+                    <option value="mautic-resource" {% if filters.type == 'mautic-resource' %}selected{% endif %}>Resource</option>
                 </select>
                 <svg class="bx--select__arrow" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
                     <path d="M8 11L3 6h10L8 11z" fill="currentColor"></path>

--- a/tests/Controller/MarketplaceControllerTest.php
+++ b/tests/Controller/MarketplaceControllerTest.php
@@ -25,6 +25,7 @@ final class MarketplaceControllerTest extends WebTestCase
         self::assertResponseIsSuccessful();
         self::assertSelectorTextContains('h1', 'Marketplace');
         self::assertSelectorTextContains('table', 'Zebra Theme');
+        self::assertSelectorTextNotContains('table', 'Beta Resource');
         self::assertSelectorTextNotContains('table', 'Alpha Plugin');
     }
 
@@ -48,6 +49,17 @@ final class MarketplaceControllerTest extends WebTestCase
         $rows = $client->getCrawler()->filter('tbody tr');
         self::assertGreaterThanOrEqual(1, $rows->count());
         self::assertStringContainsString('Zebra Theme', $rows->first()->text());
+    }
+
+    public function testFilteringByResourceType(): void
+    {
+        $client = self::createClient();
+        $client->request('GET', '/?type=mautic-resource');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('table', 'Beta Resource');
+        self::assertSelectorTextNotContains('table', 'Alpha Plugin');
+        self::assertSelectorTextNotContains('table', 'Zebra Theme');
     }
 
     public function testDetailPageLoads(): void

--- a/tests/Mock/SupabaseMockHttpClient.php
+++ b/tests/Mock/SupabaseMockHttpClient.php
@@ -47,12 +47,24 @@ final class SupabaseMockHttpClient extends MockHttpClient
             'latest_mautic_support' => true,
         ];
 
-        if (str_contains($url, '_type=mautic-theme')) {
+        $betaResource = [
+            'name' => 'mautic/beta-resource',
+            'displayname' => 'Beta Resource',
+            'description' => 'A beta resource.',
+            'type' => 'mautic-resource',
+            'repository' => 'https://github.com/mautic/beta-resource',
+            'downloads' => 200,
+            'favers' => 5,
+        ];
+
+        if (str_contains($url, '_type=mautic-resource')) {
+            $rows = [$betaResource];
+        } elseif (str_contains($url, '_type=mautic-theme')) {
             $rows = [$zebraTheme];
         } elseif (str_contains($url, '_orderby=downloads')) {
-            $rows = [$zebraTheme, $alphaPlugin];
+            $rows = [$zebraTheme, $betaResource, $alphaPlugin];
         } else {
-            $rows = [$alphaPlugin, $zebraTheme];
+            $rows = [$alphaPlugin, $betaResource, $zebraTheme];
         }
 
         $data = [['results' => $rows, 'total' => \count($rows)]];


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️
| Issue(s) addressed                     | 

## Description
The marketplace was missing support for mautic-resource packages. This PR adds fetching, filtering, and test coverage for the new type.
This PR brings a quick fix for this situation.