### PR TITLE
Harden DDEV/Supabase startup and reset workflow

### DIFF
--- a/.ddev/docker-compose.supabase.yaml
+++ b/.ddev/docker-compose.supabase.yaml
@@ -2,6 +2,7 @@ services:
   supabase-db:
     container_name: ddev-${DDEV_SITENAME}-supabase-db
     image: supabase/postgres:15.1.0.117
+    restart: unless-stopped
     labels:
       - com.ddev.site-name=${DDEV_SITENAME}
     environment:
@@ -9,10 +10,16 @@ services:
       POSTGRES_DB: postgres
     volumes:
       - supabase-db-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d postgres"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
 
   supabase-rest:
     container_name: ddev-${DDEV_SITENAME}-supabase-rest
     image: postgrest/postgrest:latest
+    restart: unless-stopped
     labels:
       - com.ddev.site-name=${DDEV_SITENAME}
     environment:
@@ -21,11 +28,13 @@ services:
       PGRST_DB_ANON_ROLE: anon
       PGRST_JWT_SECRET: mautic-marketplace-local-jwt-secret-32chars
     depends_on:
-      - supabase-db
+      supabase-db:
+        condition: service_healthy
 
   supabase-auth:
     container_name: ddev-${DDEV_SITENAME}-supabase-auth
     image: supabase/gotrue:v2.186.0
+    restart: unless-stopped
     labels:
       - com.ddev.site-name=${DDEV_SITENAME}
     environment:
@@ -42,11 +51,13 @@ services:
       GOTRUE_MAILER_AUTOCONFIRM: "true"
       GOTRUE_SMS_AUTOCONFIRM: "true"
     depends_on:
-      - supabase-db
+      supabase-db:
+        condition: service_healthy
 
   supabase-storage:
     container_name: ddev-${DDEV_SITENAME}-supabase-storage
     image: supabase/storage-api:v1.22.17
+    restart: unless-stopped
     labels:
       - com.ddev.site-name=${DDEV_SITENAME}
     environment:
@@ -61,11 +72,13 @@ services:
     volumes:
       - supabase-storage-data:/var/lib/storage
     depends_on:
-      - supabase-db
+      supabase-db:
+        condition: service_healthy
 
   supabase-realtime:
     container_name: ddev-${DDEV_SITENAME}-supabase-realtime
     image: supabase/realtime:latest
+    restart: unless-stopped
     labels:
       - com.ddev.site-name=${DDEV_SITENAME}
     environment:
@@ -76,14 +89,17 @@ services:
       DB_PASSWORD: postgres
       DB_NAME: postgres
       JWT_SECRET: mautic-marketplace-local-jwt-secret-32chars
+      METRICS_JWT_SECRET: mautic-marketplace-local-jwt-secret-32chars
       SECRET_KEY_BASE: super-secret-key-base-with-at-least-64-characters
       PORT: 4000
     depends_on:
-      - supabase-db
+      supabase-db:
+        condition: service_healthy
 
   supabase-meta:
     container_name: ddev-${DDEV_SITENAME}-supabase-meta
     image: supabase/postgres-meta:v0.95.2
+    restart: unless-stopped
     labels:
       - com.ddev.site-name=${DDEV_SITENAME}
     environment:
@@ -93,7 +109,8 @@ services:
       PG_META_DB_USER: postgres
       PG_META_DB_PASSWORD: postgres
     depends_on:
-      - supabase-db
+      supabase-db:
+        condition: service_healthy
 
   supabase-kong:
     container_name: ddev-${DDEV_SITENAME}-supabase-kong

--- a/bin/dev-reset
+++ b/bin/dev-reset
@@ -5,6 +5,6 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 cd "$ROOT_DIR"
 
-ddev stop --remove-data
+ddev stop --remove-data --omit-snapshot
 
 "$ROOT_DIR"/bin/dev-setup

--- a/docker-compose.ci.yaml
+++ b/docker-compose.ci.yaml
@@ -1,6 +1,7 @@
 services:
   supabase-db:
     image: supabase/postgres:15.1.0.117
+    restart: unless-stopped
     environment:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: postgres
@@ -14,6 +15,7 @@ services:
 
   supabase-rest:
     image: postgrest/postgrest:latest
+    restart: unless-stopped
     environment:
       PGRST_DB_URI: postgres://postgres:postgres@supabase-db:5432/postgres
       PGRST_DB_SCHEMA: public,storage,auth
@@ -25,6 +27,7 @@ services:
 
   supabase-auth:
     image: supabase/gotrue:v2.186.0
+    restart: unless-stopped
     environment:
       API_EXTERNAL_URL: http://localhost:8000
       GOTRUE_API_HOST: 0.0.0.0
@@ -44,6 +47,7 @@ services:
 
   supabase-storage:
     image: supabase/storage-api:v1.22.17
+    restart: unless-stopped
     environment:
       PGRST_JWT_SECRET: mautic-marketplace-local-jwt-secret-32chars
       ANON_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImxvY2FsLWRldiIsInJvbGUiOiJhbm9uIiwiaWF0IjoxNzcwMzIxMzM5LCJleHAiOjIwODU2ODEzMzl9.wSJj3yVYt9N7NkN5GRV-ImVZiTwG2frnPobGsDkMdD0
@@ -59,6 +63,7 @@ services:
 
   supabase-realtime:
     image: supabase/realtime:latest
+    restart: unless-stopped
     environment:
       APP_NAME: supabase-realtime
       DB_HOST: supabase-db
@@ -67,6 +72,7 @@ services:
       DB_PASSWORD: postgres
       DB_NAME: postgres
       JWT_SECRET: mautic-marketplace-local-jwt-secret-32chars
+      METRICS_JWT_SECRET: mautic-marketplace-local-jwt-secret-32chars
       SECRET_KEY_BASE: super-secret-key-base-with-at-least-64-characters
       PORT: 4000
     depends_on:
@@ -75,6 +81,7 @@ services:
 
   supabase-meta:
     image: supabase/postgres-meta:v0.95.2
+    restart: unless-stopped
     environment:
       PG_META_DB_HOST: supabase-db
       PG_META_DB_PORT: 5432


### PR DESCRIPTION
## Summary
Improve local and CI startup reliability for the embedded Supabase stack and make project reset deterministic.

## What changed
- Added missing `METRICS_JWT_SECRET` to Supabase Realtime in:
  - `.ddev/docker-compose.supabase.yaml`
  - `docker-compose.ci.yaml`
- Hardened local Supabase startup ordering in `.ddev/docker-compose.supabase.yaml`:
  - Added `supabase-db` healthcheck (`pg_isready`)
  - Switched service dependencies to health-gated `depends_on` for: rest, auth, storage, realtime, meta
  - Added `restart: unless-stopped` for core Supabase services
- Updated `bin/dev-reset` to use:
  - `ddev stop --remove-data --omit-snapshot`
  - This avoids reset failures when snapshot creation requires a temporary project start while a service is unhealthy.

## Why
- `supabase/realtime:latest` now hard-requires `METRICS_JWT_SECRET`; without it, startup fails.
- `supabase-storage` could exit during initial startup due to DB timing races (`ECONNREFUSED`) before Postgres was ready.
- `dev-reset` could fail during implicit snapshot creation even when the user intent was a hard reset.

## Validation
- `ddev restart` completes with all Supabase services healthy.
- `./bin/dev-setup` completes migrations/seeding successfully.
- Marketplace responds successfully after setup (`HTTP 200` inside web container).
- `docker compose -f docker-compose.ci.yaml config` validates successfully.

## Impact
- No production runtime behavior change.
- Improves local developer ergonomics and CI stack resilience.
