### PR TITLE
[CL-261] Fix missing gap in maintainer tags

### DIFF
--- a/templates/marketplace/detail/section--description.html.twig
+++ b/templates/marketplace/detail/section--description.html.twig
@@ -56,7 +56,7 @@
                 <!-- Maintainers -->
                 {% if package.maintainers %}
                 <dt class="type-heading-01 mt-24 mb-4">{{ 'mautic.marketplace.detail.maintainers'|trans }}</dt>
-                <dd>
+                <dd class="d-flex flex-wrap gap-4">
                     {% set maintainer_tags = package.maintainers|map(m => ({ label: m.name ?? m, color: 'blue' })) %}
                     {% include 'components/tags.html.twig' with { tags: maintainer_tags } %}
                 </dd>


### PR DESCRIPTION
after:

<img width="379" height="185" alt="image" src="https://github.com/user-attachments/assets/e4dac274-7c54-4e8d-878a-050a95c75a37" />


before:

<img width="376" height="161" alt="image" src="https://github.com/user-attachments/assets/3dc93dfd-3cde-431a-9550-1ac697fd55c8" />
