### PR TITLE
[CL-281] Maintainer name tags trigger search when clicked

### DIFF
--- a/templates/marketplace/detail/section--description.html.twig
+++ b/templates/marketplace/detail/section--description.html.twig
@@ -57,7 +57,14 @@
                 {% if package.maintainers %}
                 <dt class="type-heading-01 mt-24 mb-4">{{ 'mautic.marketplace.detail.maintainers'|trans }}</dt>
                 <dd class="d-flex flex-wrap gap-4">
-                    {% set maintainer_tags = package.maintainers|map(m => ({ label: m.name ?? m, color: 'blue' })) %}
+                    {% set maintainer_tags = package.maintainers|map(m => ({
+                        label: m.name ?? m,
+                        color: 'blue',
+                        attributes: {
+                            href: path('marketplace_index', { query: m.name ?? m }),
+                            'data-turbo-frame': '_top'
+                        }
+                    })) %}
                     {% include 'components/tags.html.twig' with { tags: maintainer_tags } %}
                 </dd>
                 {% endif %}


### PR DESCRIPTION
<img width="230" height="156" alt="image" src="https://github.com/user-attachments/assets/2088b32a-dd58-4dd7-b62d-642584d7959d" />

## trigger:

<img width="803" height="464" alt="image" src="https://github.com/user-attachments/assets/1d095059-b33f-4e2c-99d3-0f4994d4b5b2" />
