### PR TITLE
[CL-307] Convert repository links into mini cards

### DIFF
--- a/assets/styles/components/_tiles.scss
+++ b/assets/styles/components/_tiles.scss
@@ -148,18 +148,6 @@
     cursor: pointer;
 }
 
-.nav-tabs-contained + .tab-content {
-    .tile {
-        background-color: var(--layer-02);
-
-        &.tile-clickable,
-        &.tile-selectable {
-            &:hover { background: var(--layer-hover-02); }
-        }
-    }
-}
-
-
 .card .card__wrapper,
 .card .card__wrapper[aspect-ratio="2:1"] {
     display: flex;

--- a/templates/components/card.html.twig
+++ b/templates/components/card.html.twig
@@ -37,14 +37,16 @@
     {% if heading is defined %}
         <div class="card__heading-wrapper">
             <h3 class="card-heading
-                {% if type == 'feature--large' %}
-                    type-fluid-heading-04 mb-32
-                {% else %}
-                    type-heading-0{{ type == 'link' ? '2' : '3' }}
-                    {% if type != 'pictogram' and type != 'link' %}
-                        mb-32
-                    {% endif %}
-                {% endif %}
+                {{ type == 'feature--large' 
+                    ? 'type-fluid-heading-04 mb-32' 
+                    : type == 'mini' 
+                        ? 'type-body-compact-01 mb-0' 
+                        : type == 'link' 
+                            ? 'type-heading-02' 
+                            : type == 'pictogram'
+                                ? 'type-heading-03'
+                                : 'type-heading-03 mb-32'
+                }}
                 text-break">{{ heading|trans }}</h3>
         </div>
     {% endif %}
@@ -76,7 +78,8 @@
 
 {% set common_icon_content %}
     {% if icon is defined %}
-        <i class="{{ ctaIcons[ctaType] }} link-primary ri-lg ms-auto" aria-hidden="true"></i>
+        <i class="{{ type == 'mini' ? icon : ctaIcons[ctaType] }} link-primary {{ type == 'mini' ? 'ri-xl' : 'ri-lg' }} ms-auto" aria-hidden="true"></i>
+   
     {% endif %}
 {% endset %}
 
@@ -277,4 +280,22 @@
             icon: ctaIcons[ctaType],
             attributes: common_newtab_attributes,
         } %}
+
+    {# === MINI TYPE === #}
+    {% elseif type == 'mini' %}
+        {% set cardContent %}
+            <div class="card__content">
+                <div class="d-flex jc-space-between align-items-center gap-16">
+                    {{ common_heading_content }}
+                    {{ common_icon_content }}
+                </div>
+            </div>
+        {% endset %}
+        {% include 'components/tile.html.twig' with {
+            type: 'clickable',
+            content: cardContent,
+            className: 'card p-0 card--link justify-content-center' ~ (className is defined and className is not empty ? ' ' ~ className : ''),
+            href: href|default(null),
+            attributes: (attributes|default({}))|merge(common_newtab_attributes),
+        } only %}
     {% endif %}

--- a/templates/components/tile.html.twig
+++ b/templates/components/tile.html.twig
@@ -101,17 +101,4 @@
             </div>
         </div>
     </div>
-
-{# === MINI TYPE === #}
-{% elseif type == 'mini' %}
-    <a href="{{ href|default('#') }}" class="tile tile--clickable {{ className|default('') }}" {% if attributes is defined and attributes is not empty %}{% for attr_key, attr_value in attributes %}{{ attr_key }}="{{ attr_value }}" {% endfor %}{% endif %}>
-        <div class="d-flex jc-space-between ai-center">
-            <div class="tile-title text-break">{{ title|trans }}</div>
-            {% if icon is defined %}
-                <div class="tile-icon">
-                    <i class="{{ icon }} text-interactive"></i>
-                </div>
-            {% endif %}
-        </div>
-    </a>
-{% endif %} 
+{% endif %}

--- a/templates/marketplace/detail/section--description.html.twig
+++ b/templates/marketplace/detail/section--description.html.twig
@@ -69,37 +69,43 @@
                 </dd>
                 {% endif %}
                 </div>
-                
-                <!-- Repository -->
-                <dt class="type-heading-01 mt-24 mb-8">{{ 'mautic.marketplace.detail.repository'|trans }}</dt>
-                {% if package.repository or package.url %}
+            </div>
+
+            {% if package.repository or package.url %}
+                <div class="d-grid mt-12">
                     {% if package.repository %}
-                    <dd>
-                        <i class="ri-github-fill ri-lg" aria-hidden="true"></i>
-                        <a href="{{ package.repository }}" target="_blank" rel="noopener">
-                            {% set repoParts = package.repository|split('/') %}
-                            {{ 'mautic.marketplace.detail.repository.github'|trans({
+                        {% set repoParts = package.repository|split('/') %}
+                        {% include 'components/card.html.twig' with {
+                            type: 'mini',
+                            href: package.repository,
+                            heading: 'mautic.marketplace.detail.repository.github'|trans({
                                 '%repository%': repoParts[repoParts|length-2] ~ '/' ~ repoParts[repoParts|length-1]
-                            }) }}
-                        </a>
-                    </dd>
-                    {% endif %}
-                    {% if package.url %}
-                    <dd>
-                        <i class="ri-box-2-fill ri-lg" aria-hidden="true"></i>
-                            {% set pkgParts = package.url|split('/') %}
-                            <a href="{{ package.url }}" target="_blank" rel="noopener">
-                                {{ 'mautic.marketplace.detail.repository.packagist'|trans({
-                                    '%package%': pkgParts[pkgParts|length-2] ~ '/' ~ pkgParts[pkgParts|length-1]
-                                }) }}
-                            </a>
-                    </dd>
+                            }),
+                            icon: 'ri-github-fill',
+                            attributes: {
+                                target: '_blank',
+                                rel: 'noopener'
+                            }
+                        } %}
                     {% endif %}
 
-                {% else %}
-                <dd class="text-helper">{{ 'mautic.marketplace.detail.unknown'|trans }}</dd>
-                {% endif %}
-            </div>
+                    {% if package.url %}
+                        {% set pkgParts = package.url|split('/') %}
+                        {% include 'components/card.html.twig' with {
+                            type: 'mini',
+                            href: package.url,
+                            heading: 'mautic.marketplace.detail.repository.packagist'|trans({
+                                '%package%': pkgParts[pkgParts|length-2] ~ '/' ~ pkgParts[pkgParts|length-1]
+                            }),
+                            icon: 'ri-box-2-fill',
+                            attributes: {
+                                target: '_blank',
+                                rel: 'noopener'
+                            }
+                        } %}
+                    {% endif %}
+                </div>
+            {% endif %}
 
             <!-- Versions -->
 


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | --------------------------
| Bug fix?          | ❌ <!-- Use emojis to indicate positive or negative for each item. -->
| New feature/enhancement?      | ✔️
| Automated tests included?              | ❌ 

## Description

This PR introduces reusable mini cards for repository and package links on marketplace package detail pages.

---
### 📋 Steps to test this PR:

1. Open a marketplace package detail page that has repository and package URLs.
2. Confirm the GitHub and Packagist links appear as compact cards with the expected icons.
3. Click each mini card and confirm it opens the correct external URL in a new tab.
