### PR TITLE
CL-308: Trust X-Forwarded headers behind TLS-terminating proxy

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -5,6 +5,9 @@ framework:
     # Note that the session will be started ONLY if you read or write from it.
     session: true
 
+    trusted_proxies: 'private_ranges'
+    trusted_headers: ['x-forwarded-for', 'x-forwarded-host', 'x-forwarded-proto', 'x-forwarded-port', 'x-forwarded-prefix']
+
     #esi: true
     #fragments: true
 

--- a/templates/marketplace/detail/section--reviews.html.twig
+++ b/templates/marketplace/detail/section--reviews.html.twig
@@ -135,6 +135,7 @@
                     variant: 'tertiary',
                     icon: 'ri-login-box-line',
                     href: path('auth_login', { returnTo: app.request.requestUri }),
+                    attributes: { 'data-turbo': 'false' },
                 }]
             } only %}
         {% endif %}


### PR DESCRIPTION
Symfony was generating http:// callback URLs on staging because it wasn't trusting the reverse proxy's X-Forwarded-* headers, so Auth0 rejected the login redirect (allowlist is https:// only).                                     
                                                                                                                                                                                                                                     
Fix: set trusted_proxies: 'private_ranges' and declare the standard trusted_headers list in framework.yaml so RequestContext honors X-Forwarded-Proto and generates https:// URLs.                                                   
   
Also disabled Turbo on the login link so the OAuth redirect isn't intercepted. 