### PR TITLE
[CL-310] Fix custom heading classes font family config

### DIFF
--- a/assets/styles/components/_type.scss
+++ b/assets/styles/components/_type.scss
@@ -9,6 +9,20 @@ $font-family-serif: "Source Serif 4", "Times New Roman", Times, Baskerville, Geo
   color: var(--link-primary);
 }
 
+.type-heading-01,
+.type-heading-02,
+.type-heading-03,
+.type-heading-04,
+.type-heading-05,
+.type-heading-06,
+.type-heading-07,
+.type-fluid-heading-03,
+.type-fluid-heading-04,
+.type-fluid-heading-05,
+.type-fluid-heading-06 {
+  font-family: $headings-font-family;
+}
+
 .type-code-01 {
   font-size: var(--code-01-font-size);
   line-height: var(--code-01-line-height);

--- a/assets/styles/components/_type.scss
+++ b/assets/styles/components/_type.scss
@@ -23,6 +23,25 @@ $font-family-serif: "Source Serif 4", "Times New Roman", Times, Baskerville, Geo
   font-family: $headings-font-family;
 }
 
+.type-code-01,
+.type-code-02 {
+  font-family: $font-family-monospace;
+}
+
+.type-label-01,
+.type-label-02,
+.type-helper-text-01,
+.type-helper-text-02,
+.type-legal-01,
+.type-legal-02,
+.type-body-compact-01,
+.type-body-compact-02,
+.type-body-01,
+.type-body-02,
+.type-fluid-paragraph-01 {
+  font-family: $font-family-sans-serif;
+}
+
 .type-code-01 {
   font-size: var(--code-01-font-size);
   line-height: var(--code-01-line-height);

--- a/templates/components/content-block.html.twig
+++ b/templates/components/content-block.html.twig
@@ -1,6 +1,6 @@
 <div class="{% if hasBorder is defined and hasBorder %}mb-64{% else %}mb-160{% endif %}">
     {% if heading is defined %}
-    <div aria-level="2" class="content-block__heading type-fluid-heading-05 mb-32 text-break">{{ heading|trans }}</div>
+    <h2 class="content-block__heading type-fluid-heading-05 mb-32 text-break">{{ heading|trans }}</h2>
     {% endif %}
     
     {% if subheading is defined %}

--- a/templates/components/content-group.html.twig
+++ b/templates/components/content-group.html.twig
@@ -1,6 +1,6 @@
 <div class="mt-32 mb-48">
     {% if heading is defined %}
-    <div aria-level="3" class="content-block__heading type-fluid-heading-04 mb-32 text-break">{{ heading|trans }}</div>
+    <h3 class="content-block__heading type-fluid-heading-04 mb-32 text-break">{{ heading|trans }}</h3>
     {% endif %}
     
     {% if copy is defined %}

--- a/templates/components/lead-space.html.twig
+++ b/templates/components/lead-space.html.twig
@@ -41,8 +41,8 @@ Variables:
                                 {% endif %}
                                 <div class="row">
                                     <div class="col-xs-12 col-md-9 col-lg-6">
-                                        <h1 type-style="display-01" highlight="" role="heading" aria-level="1"
-                                            class="leadspace--heading" slot="heading">
+                                        <h1 highlight=""
+                                            class="type-display-01 leadspace--heading" slot="heading">
                                             <div class="{% if variant == 'short' %}type-fluid-heading-05{% else %}type-fluid-display-01{% endif %} text-break{% if gradientStyleSchemeColor is defined %} leadspace__context-aware-color{% endif %}">
                                                 {{ heading|trans }}
                                             </div>


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | --------------------------
| Bug fix?          | ✔️
| New feature/enhancement?      | ❌
| Automated tests included?              | ❌ 

## Description

Fixes custom heading utility classes so they apply the configured heading font family consistently.

---
### 📋 Steps to test this PR:

1. Run the app and open any page using custom heading utility classes such as `type-heading-01` or `type-fluid-heading-05`.
2. Confirm the heading renders with the configured headings font family.
3. Inspect content block, content group, and lead space headings to confirm semantic heading tags still render correctly.