### PR TITLE
 fix supabase migrations and functions on manual prod deploys

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -11,7 +11,9 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  deploy_prod:
+  deploy_supabase:
+    # Apply DB migrations and functions on BOTH tag pushes and manual dispatch,
+    # so the app container can never ship ahead of the database schema.
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
@@ -23,6 +25,36 @@ jobs:
             exit 1
           fi
 
+      - name: Guard manual dispatch to main
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
+            echo "Manual prod deploys must run from main (got ${GITHUB_REF})."
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Supabase functions and migrations
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
+        run: |
+          supabase link --project-ref "${SUPABASE_PROJECT_ID}"
+          supabase functions deploy fetch_package
+          supabase db push
+
+  deploy_prod:
+    needs: deploy_supabase
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -73,31 +105,3 @@ jobs:
             APP_PORT=8080 \
             APP_ENV_FILE=/etc/marketplace/prod.env \
             "${DEPLOY_SCRIPT}"
-
-  deploy_tag_supabase:
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
-    steps:
-      - name: Validate tag format
-        run: |
-          if [[ ! "${GITHUB_REF_NAME}" =~ ^[0-9]+\.[0-9]+\..+$ ]]; then
-            echo "Tag must be MAJOR.MINOR.<anything> with numeric MAJOR and MINOR"
-            exit 1
-          fi
-
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Supabase CLI
-        uses: supabase/setup-cli@v1
-        with:
-          version: latest
-
-      - name: Supabase functions and migrations
-        env:
-          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-          SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
-        run: |
-          supabase link --project-ref "${SUPABASE_PROJECT_ID}"
-          supabase functions deploy fetch_package
-          supabase db push


### PR DESCRIPTION
 `deploy-prod.yml` deployed the app container on both tag pushes and `workflow_dispatch`, but the Supabase job (`supabase db push` + `supabase functions deploy fetch_package`) ran only on tag  pushes.


**Fix**
  
  - Rename `deploy_tag_supabase` → `deploy_supabase` and run it on **both** tag pushes and `workflow_dispatch`.
  - `deploy_prod` now `needs: deploy_supabase`, so migrations and functions apply **before** the  container swap — the schema can no longer fall behind the code.
  - Guard `workflow_dispatch` to run only from `main`.