### PR TITLE
 Prune unused Docker images during prod deploy to avoid disk exhaustion

### DIFF
--- a/scripts/deploy/remote_deploy.sh
+++ b/scripts/deploy/remote_deploy.sh
@@ -30,8 +30,16 @@ if ! command -v docker >/dev/null 2>&1; then
   exit 1
 fi
 
+# Reclaim disk before loading the new image so deploys don't fail with
+# "no space left on device". Prunes images no longer used by any container
+# (the running app's image is retained), clearing old images from past deploys.
+echo "Reclaiming disk: pruning unused Docker images..."
+docker image prune -af || true
+
 if [[ -f "${IMAGE_TAR}" ]]; then
   docker load -i "${IMAGE_TAR}"
+  # The tarball is only needed for the load step; remove it so /tmp doesn't fill up.
+  rm -f "${IMAGE_TAR}" || true
 fi
 
 if docker ps -a --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
@@ -51,6 +59,10 @@ docker run -d \
   -p "127.0.0.1:${APP_PORT}:80" \
   "${APP_ENV_FILE_ARG[@]}" \
   "${IMAGE_TAG}"
+
+# The previous image is now unused (replaced by the new container); drop it so
+# old images don't accumulate between deploys.
+docker image prune -af || true
 
 PROD_DOMAIN="${APP_DOMAIN:-}"
 PROD_PORT="${APP_DOMAIN_PORT:-8080}"

--- a/scripts/deploy/remote_deploy.sh
+++ b/scripts/deploy/remote_deploy.sh
@@ -34,12 +34,12 @@ fi
 # "no space left on device". Prunes images no longer used by any container
 # (the running app's image is retained), clearing old images from past deploys.
 echo "Reclaiming disk: pruning unused Docker images..."
-docker image prune -af || true
+docker image prune -af || echo "Warning: failed to prune unused Docker images (continuing)" >&2
 
 if [[ -f "${IMAGE_TAR}" ]]; then
   docker load -i "${IMAGE_TAR}"
   # The tarball is only needed for the load step; remove it so /tmp doesn't fill up.
-  rm -f "${IMAGE_TAR}" || true
+  rm -f "${IMAGE_TAR}" || echo "Warning: failed to remove image tarball ${IMAGE_TAR} (continuing)" >&2
 fi
 
 if docker ps -a --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
@@ -62,7 +62,7 @@ docker run -d \
 
 # The previous image is now unused (replaced by the new container); drop it so
 # old images don't accumulate between deploys.
-docker image prune -af || true
+docker image prune -af || echo "Warning: failed to prune unused Docker images (continuing)" >&2
 
 PROD_DOMAIN="${APP_DOMAIN:-}"
 PROD_PORT="${APP_DOMAIN_PORT:-8080}"


### PR DESCRIPTION
The droplet ran out of space mid-deploy ("no space left on device" while loading the image), because old images and deploy tarballs accumulated across deploys.
  
  remote_deploy.sh now:

  - prunes unused Docker images before loading the new image (frees space;
    the running container's image is retained, so staging is unaffected)
  - removes the image tarball after loading
  - prunes once more after the container swap to drop the replaced image