### PR TITLE
Setting a version for Supabase CLI to avoid an extra request that hits  a rate limit

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -37,9 +37,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Supabase CLI
-        uses: supabase/setup-cli@v1
+        uses: supabase/setup-cli@ab058987d8d6c725971f6cf9d0b5c98467e30bd1 # v1
         with:
-          version: latest
+          version: 2.109.0
 
       - name: Supabase functions and migrations
         env:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -192,9 +192,9 @@ jobs:
           ref: ${{ needs.deploy_staging.outputs.ref }}
 
       - name: Setup Supabase CLI
-        uses: supabase/setup-cli@v1
+        uses: supabase/setup-cli@ab058987d8d6c725971f6cf9d0b5c98467e30bd1 # v1
         with:
-          version: latest
+          version: 2.109.0
 
       - name: Supabase functions and migrations (staging)
         env:


### PR DESCRIPTION

Error: Failed to resolve latest Supabase CLI release: rate limit exceeded

See https://github.com/mautic/mautic-public-marketplace/actions/runs/28503401487