### PR TITLE
Deploy edge function via Management API to fix internal 500

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -47,7 +47,7 @@ jobs:
           SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
         run: |
           supabase link --project-ref "${SUPABASE_PROJECT_ID}"
-          supabase functions deploy fetch_package
+          supabase functions deploy fetch_package --use-api
           supabase db push
 
   deploy_prod:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -202,6 +202,6 @@ jobs:
           SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_STAGING_PROJECT_ID }}
         run: |
           supabase link --project-ref "${SUPABASE_PROJECT_ID}"
-          supabase functions deploy fetch_package
+          supabase functions deploy fetch_package --use-api
           supabase migration list --linked
           supabase db push --include-all


### PR DESCRIPTION
The `version: latest` pin got past the ratelimit, but then it hit a different, Supabase-side error:

 500 "Failed to set function store"

Turned out the default local bundling path was the problem. Deploying with`--use-api` (bundles via the Management API) works - I deployed fetch_package to prod manually and it went through, no more 500. Prod should be fixed now.