### PR TITLE
Fix/publish upload size limit and bug fixing

### DIFF
--- a/assets/publish-upload.js
+++ b/assets/publish-upload.js
@@ -27,7 +27,7 @@ function initPublishUpload() {
         }
         switch (response.status) {
             case 413:
-                return 'The campaign archive is too large to upload. The maximum allowed size is 64 MB — try removing large images or assets from the campaign and publish again.';
+                return 'The campaign archive is too large to upload. The maximum allowed size is 50 MB — try removing large images or assets from the campaign and publish again.';
             case 401:
             case 403:
                 return 'Your marketplace session has expired or you are not allowed to publish. Please log in again and retry.';

--- a/assets/publish-upload.js
+++ b/assets/publish-upload.js
@@ -21,6 +21,25 @@ function initPublishUpload() {
 
     const GENERIC_ERROR = "Something went wrong while publishing. Please try again, or contact support if it keeps happening.";
 
+    function errorMessageForResponse(response, data) {
+        if (data && data.error) {
+            return data.error;
+        }
+        switch (response.status) {
+            case 413:
+                return 'The campaign archive is too large to upload. The maximum allowed size is 64 MB — try removing large images or assets from the campaign and publish again.';
+            case 401:
+            case 403:
+                return 'Your marketplace session has expired or you are not allowed to publish. Please log in again and retry.';
+            case 502:
+            case 503:
+            case 504:
+                return 'The marketplace server is temporarily unavailable. Please try again in a few minutes.';
+            default:
+                return GENERIC_ERROR + ' (HTTP ' + response.status + ')';
+        }
+    }
+
     // Notify the Mautic opener that this popup is ready to receive the archive.
     // We use '*' for the targetOrigin because we don't know which Mautic host the
     // user is publishing from — the popup is the trust boundary, not the message.
@@ -79,7 +98,7 @@ function initPublishUpload() {
             try { data = await response.json(); } catch (e) { /* non-JSON */ }
 
             if (!response.ok) {
-                throw new Error((data && data.error) ? data.error : GENERIC_ERROR);
+                throw new Error(errorMessageForResponse(response, data));
             }
 
             if (!data) {

--- a/scripts/deploy/remote_deploy.sh
+++ b/scripts/deploy/remote_deploy.sh
@@ -87,6 +87,10 @@ server {
     listen 80;
     server_name ${PROD_DOMAIN};
 
+    # Keep in sync with post_max_size in the Dockerfile; nginx defaults to 1M
+    # which rejects package uploads with 413 before they reach the app.
+    client_max_body_size 64M;
+
     location / {
         proxy_pass http://127.0.0.1:${PROD_PORT};
         proxy_set_header Host \$host;
@@ -103,6 +107,10 @@ NGINX_CONF
 server {
     listen 80;
     server_name ${STAGING_DOMAIN};
+
+    # Keep in sync with post_max_size in the Dockerfile; nginx defaults to 1M
+    # which rejects package uploads with 413 before they reach the app.
+    client_max_body_size 64M;
 
     location / {
         proxy_pass http://127.0.0.1:${STAGING_PORT};

--- a/src/Marketplace/PackageImageUploader.php
+++ b/src/Marketplace/PackageImageUploader.php
@@ -85,6 +85,58 @@ final class PackageImageUploader
         return self::BUCKET.'/'.$objectPath;
     }
 
+    /**
+     * Extracts the gallery images packed in a Mautic-shared ZIP (gallery/image_N.<ext> with an
+     * optional gallery/image_N.alt.txt alongside, see CampaignShareService::share), stores them
+     * in marketplace-owned storage, and returns entries shaped for packages.gallery. Returns an
+     * empty list when the archive carries no gallery images.
+     *
+     * @return list<array{url: string, alt: string}>
+     *
+     * @throws SupabaseApiException
+     */
+    public function uploadGalleryFromZip(string $packageName, string $zipPath): array
+    {
+        $zip = new \ZipArchive();
+        if (true !== $zip->open($zipPath)) {
+            return [];
+        }
+
+        $gallery = [];
+
+        try {
+            // Mautic's share form allows up to 8 gallery images, numbered from 1.
+            for ($i = 1; $i <= 8; ++$i) {
+                foreach (self::ALLOWED_EXTENSIONS as $extension => $mime) {
+                    $contents = $zip->getFromName('gallery/image_'.$i.'.'.$extension);
+                    if (false === $contents || '' === $contents) {
+                        continue;
+                    }
+
+                    if (\strlen($contents) > self::MAX_BYTES) {
+                        // An oversized gallery image shouldn't block the whole publish; skip it.
+                        continue 2;
+                    }
+
+                    $objectPath = $this->slugify($packageName).'/gallery/'.$i.'.'.$extension;
+                    $this->supabaseClient->uploadStorageObject(self::BUCKET, $objectPath, $contents, $mime);
+
+                    $alt = $zip->getFromName('gallery/image_'.$i.'.alt.txt');
+                    $gallery[] = [
+                        'url' => self::BUCKET.'/'.$objectPath,
+                        'alt' => \is_string($alt) ? trim($alt) : '',
+                    ];
+
+                    continue 2;
+                }
+            }
+
+            return $gallery;
+        } finally {
+            $zip->close();
+        }
+    }
+
     private function upload(string $packageName, UploadedFile $file, string $prefix): string
     {
         $mime = $file->getMimeType() ?? '';

--- a/src/Marketplace/PackageImageUploader.php
+++ b/src/Marketplace/PackageImageUploader.php
@@ -108,14 +108,20 @@ final class PackageImageUploader
             // Mautic's share form allows up to 8 gallery images, numbered from 1.
             for ($i = 1; $i <= 8; ++$i) {
                 foreach (self::ALLOWED_EXTENSIONS as $extension => $mime) {
-                    $contents = $zip->getFromName('gallery/image_'.$i.'.'.$extension);
-                    if (false === $contents || '' === $contents) {
+                    $stat = $zip->statName('gallery/image_'.$i.'.'.$extension);
+                    if (false === $stat) {
                         continue;
                     }
 
-                    if (\strlen($contents) > self::MAX_BYTES) {
-                        // An oversized gallery image shouldn't block the whole publish; skip it.
+                    if ($stat['size'] > self::MAX_BYTES) {
+                        // Reject on the declared uncompressed size before decompressing, so a
+                        // crafted entry (zip bomb) can't exhaust memory; skip the oversized image.
                         continue 2;
+                    }
+
+                    $contents = $zip->getFromName('gallery/image_'.$i.'.'.$extension);
+                    if (false === $contents || '' === $contents) {
+                        continue;
                     }
 
                     $objectPath = $this->slugify($packageName).'/gallery/'.$i.'.'.$extension;
@@ -175,6 +181,17 @@ final class PackageImageUploader
 
         try {
             foreach (array_keys(self::ALLOWED_EXTENSIONS) as $extension) {
+                $stat = $zip->statName('banner.'.$extension);
+                if (false === $stat) {
+                    continue;
+                }
+
+                if ($stat['size'] > self::MAX_BYTES) {
+                    // Reject on the declared uncompressed size before decompressing, so a
+                    // crafted entry (zip bomb) can't exhaust memory; treat it as no banner.
+                    continue;
+                }
+
                 $contents = $zip->getFromName('banner.'.$extension);
                 if (false !== $contents && '' !== $contents) {
                     return [$extension, $contents];

--- a/src/Marketplace/PackageSubmitService.php
+++ b/src/Marketplace/PackageSubmitService.php
@@ -78,10 +78,12 @@ final class PackageSubmitService
         $request = $this->requestFromComposer($composerData);
         $zipUrl = $this->zipUploader->upload($request->name, $request->version, $zipPath);
 
-        // Mautic packs the banner inside the shared ZIP, so extract it here instead of from a form field.
+        // Mautic packs the banner and gallery inside the shared ZIP, so extract them here
+        // instead of from form fields.
         $bannerUrl = $this->imageUploader->uploadBannerFromZip($request->name, $zipPath);
+        $gallery = $this->imageUploader->uploadGalleryFromZip($request->name, $zipPath);
 
-        return $this->upsertPackage($composerData, $request, $user, $zipUrl, $bannerUrl, []);
+        return $this->upsertPackage($composerData, $request, $user, $zipUrl, $bannerUrl, $gallery);
     }
 
     /**

--- a/tests/Controller/UploadApiControllerTest.php
+++ b/tests/Controller/UploadApiControllerTest.php
@@ -70,6 +70,26 @@ final class UploadApiControllerTest extends WebTestCase
         self::assertTrue($data['created']);
     }
 
+    public function testSuccessfulUploadWithBannerAndGallery(): void
+    {
+        $client = self::createClient();
+        $client->loginUser(new Auth0User('auth0|test123', 'Test User', 'test@example.com', null), 'main');
+        $zipBytes = ValidZipFixture::build(null, [
+            'banner.png' => 'png-banner-bytes',
+            'gallery/image_1.png' => 'png-gallery-bytes',
+            'gallery/image_1.alt.txt' => 'First screenshot',
+            'gallery/image_2.jpg' => 'jpg-gallery-bytes',
+        ]);
+        $client->request('POST', '/api/package/upload', files: [
+            'package' => $this->makeUploadedFile($zipBytes),
+        ]);
+
+        self::assertResponseStatusCodeSame(201);
+        $data = json_decode((string) $client->getResponse()->getContent(), true);
+        self::assertSame('testuser/test-campaign', $data['package_name']);
+        self::assertTrue($data['created']);
+    }
+
     public function testUploadWithNonZipBytesReturnsError(): void
     {
         $client = self::createClient();

--- a/tests/Marketplace/PackageImageUploaderTest.php
+++ b/tests/Marketplace/PackageImageUploaderTest.php
@@ -58,6 +58,29 @@ final class PackageImageUploaderTest extends KernelTestCase
         self::assertNull($this->uploader->uploadBannerFromZip('testuser/no-banner', $zipPath));
     }
 
+    public function testUploadsGalleryImagesWithAltTexts(): void
+    {
+        $zipPath = $this->makeZip([
+            'gallery/image_1.png' => 'png-bytes',
+            'gallery/image_1.alt.txt' => 'First screenshot',
+            'gallery/image_2.jpg' => 'jpg-bytes',
+        ]);
+
+        $result = $this->uploader->uploadGalleryFromZip('testuser/test-campaign', $zipPath);
+
+        self::assertSame([
+            ['url' => 'package-media/testuser/test-campaign/gallery/1.png', 'alt' => 'First screenshot'],
+            ['url' => 'package-media/testuser/test-campaign/gallery/2.jpg', 'alt' => ''],
+        ], $result);
+    }
+
+    public function testReturnsEmptyGalleryWhenArchiveHasNoGalleryImages(): void
+    {
+        $zipPath = $this->makeZip(['composer.json' => '{}', 'banner.png' => 'png-bytes']);
+
+        self::assertSame([], $this->uploader->uploadGalleryFromZip('testuser/no-gallery', $zipPath));
+    }
+
     /**
      * @param array<string, string> $entries
      */


### PR DESCRIPTION
- Set client_max_body_size 64M in the Nginx reverse proxy config (prod and staging); the default 1M rejected campaign archives with 413 before they  reached the app.

- Show specific publish error messages for 413, 401/403 and 502-504 instead  of the generic one, and append the HTTP status to the generic fallback.

- Extract gallery images (gallery/image_N + alt texts) from Mautic-shared  ZIPs and store them alongside the banner, so they display on the package page. Covered by new unit and API tests.