### PR TITLE
Add package download flow on the detail page

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -72,6 +72,14 @@ publish_upload:
     controller: App\Controller\PublishController::upload
     methods: [GET]
 
+# Must precede marketplace_detail: its greedy {package} would otherwise swallow /download.
+marketplace_package_download:
+    path: /package/{package}/download
+    controller: App\Controller\MarketplaceController::download
+    methods: [GET]
+    requirements:
+        package: .+
+
 marketplace_detail:
     path: /package/{package}
     controller: App\Controller\MarketplaceController::detail

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -40,6 +40,11 @@ when@test:
             arguments:
                 $httpClient: '@App\Tests\Mock\SupabaseMockHttpClient'
 
+        App\Marketplace\PackageDownloadArchiveBuilder:
+            autowire: true
+            arguments:
+                $httpClient: '@App\Tests\Mock\SupabaseMockHttpClient'
+
         App\Tests\Mock\PackagistMockHttpClient:
             class: App\Tests\Mock\PackagistMockHttpClient
 

--- a/src/Controller/MarketplaceController.php
+++ b/src/Controller/MarketplaceController.php
@@ -193,12 +193,13 @@ final class MarketplaceController extends AbstractController
         }
 
         $user = $this->getUser();
-        if ($user instanceof Auth0User) {
-            try {
-                $this->apiClient->recordDownload($detail->name, $version, $user->getUserIdentifier());
-            } catch (SupabaseApiException) {
-                // History is best-effort; never block the download on it.
-            }
+        $downloadedBy = $user instanceof Auth0User ? $user->getUserIdentifier() : null;
+        try {
+            // Record every download, including anonymous ones (null user id), so the
+            // history reflects total pulls and not just those from signed-in users.
+            $this->apiClient->recordDownload($detail->name, $version, $downloadedBy);
+        } catch (SupabaseApiException) {
+            // History is best-effort; never block the download on it.
         }
 
         return new RedirectResponse($this->downloadUrl($detail, $distUrl, $version));

--- a/src/Controller/MarketplaceController.php
+++ b/src/Controller/MarketplaceController.php
@@ -13,6 +13,7 @@ use App\Marketplace\MarketplaceApiClient;
 use App\Marketplace\MauticVersionsProvider;
 use App\Marketplace\PackageDetailPageContextBuilder;
 use App\Supabase\Exception\SupabaseApiException;
+use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -33,6 +34,7 @@ final class MarketplaceController extends AbstractController
         private readonly MauticVersionConstraintFormatter $mauticVersionConstraintFormatter,
         private readonly LanguageOptions $languageOptions,
         private readonly MauticVersionsProvider $mauticVersionsProvider,
+        private readonly LoggerInterface $logger,
     ) {
     }
 
@@ -178,7 +180,13 @@ final class MarketplaceController extends AbstractController
     {
         try {
             $detail = $this->apiClient->getPackage($package);
-        } catch (SupabaseApiException) {
+        } catch (SupabaseApiException $exception) {
+            // Surfaced to the visitor as a 404 below, so leave a trace that the
+            // real cause was an API failure and not a missing package.
+            $this->logger->error('Could not load the package for download.', [
+                'exception' => $exception,
+                'package' => $package,
+            ]);
             $detail = null;
         }
 
@@ -198,8 +206,13 @@ final class MarketplaceController extends AbstractController
             // Record every download, including anonymous ones (null user id), so the
             // history reflects total pulls and not just those from signed-in users.
             $this->apiClient->recordDownload($detail->name, $version, $downloadedBy);
-        } catch (SupabaseApiException) {
+        } catch (SupabaseApiException $exception) {
             // History is best-effort; never block the download on it.
+            $this->logger->warning('Could not record the package download in the download history.', [
+                'exception' => $exception,
+                'package' => $detail->name,
+                'version' => $version,
+            ]);
         }
 
         return new RedirectResponse($this->downloadUrl($detail, $distUrl, $version));

--- a/src/Controller/MarketplaceController.php
+++ b/src/Controller/MarketplaceController.php
@@ -12,12 +12,15 @@ use App\Marketplace\LanguageOptions;
 use App\Marketplace\MarketplaceApiClient;
 use App\Marketplace\MauticVersionsProvider;
 use App\Marketplace\PackageDetailPageContextBuilder;
+use App\Marketplace\PackageDownloadArchiveBuilder;
 use App\Supabase\Exception\SupabaseApiException;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 final class MarketplaceController extends AbstractController
 {
@@ -34,6 +37,7 @@ final class MarketplaceController extends AbstractController
         private readonly MauticVersionConstraintFormatter $mauticVersionConstraintFormatter,
         private readonly LanguageOptions $languageOptions,
         private readonly MauticVersionsProvider $mauticVersionsProvider,
+        private readonly PackageDownloadArchiveBuilder $downloadArchiveBuilder,
         private readonly LoggerInterface $logger,
     ) {
     }
@@ -176,7 +180,7 @@ final class MarketplaceController extends AbstractController
         return $this->render('marketplace/detail.html.twig', $page['context'], new Response('', $page['status_code']));
     }
 
-    public function download(string $package): RedirectResponse
+    public function download(string $package): Response
     {
         try {
             $detail = $this->apiClient->getPackage($package);
@@ -215,23 +219,47 @@ final class MarketplaceController extends AbstractController
             ]);
         }
 
-        return new RedirectResponse($this->downloadUrl($detail, $distUrl, $version));
+        return $this->archiveResponse($detail, $distUrl, $version);
     }
 
     /**
-     * Builds the browser-facing archive URL. For marketplace-hosted archives, the
-     * storage ?download parameter names the saved file after the package (e.g.
-     * "Open House Re-engagement 1.0.0.zip") instead of the bare version number.
+     * Serves the archive of a marketplace-hosted package with its banner and
+     * gallery images bundled in; falls back to redirecting to the stored (or
+     * externally hosted) archive when there are no images to add. On the
+     * redirect path the storage ?download parameter names the saved file after
+     * the package (e.g. "Open House Re-engagement 1.0.0.zip") instead of the
+     * bare version number.
      */
-    private function downloadUrl(PackageDetail $detail, string $distUrl, ?string $version): string
+    private function archiveResponse(PackageDetail $detail, string $distUrl, ?string $version): Response
     {
         $url = $this->apiClient->toPublicStorageUrl($distUrl);
 
         if (!str_contains($url, '/storage/v1/object/public/')) {
             // Externally hosted dist — leave the URL untouched.
-            return $url;
+            return new RedirectResponse($url);
         }
 
+        $filename = $this->downloadFilename($detail, $version);
+
+        $archivePath = $this->downloadArchiveBuilder->build($detail, $url);
+        if (null !== $archivePath) {
+            $response = new BinaryFileResponse($archivePath);
+            $response->deleteFileAfterSend(true);
+            $response->headers->set('Content-Type', 'application/zip');
+            $response->setContentDisposition(
+                ResponseHeaderBag::DISPOSITION_ATTACHMENT,
+                $filename,
+                (string) preg_replace('/[^\x20-\x24\x26-\x7e]/', '_', $filename),
+            );
+
+            return $response;
+        }
+
+        return new RedirectResponse($url.'?download='.rawurlencode($filename));
+    }
+
+    private function downloadFilename(PackageDetail $detail, ?string $version): string
+    {
         $name = trim($detail->displayName ?? '');
         if ('' === $name) {
             $name = str_contains($detail->name, '/') ? explode('/', $detail->name, 2)[1] : $detail->name;
@@ -239,9 +267,8 @@ final class MarketplaceController extends AbstractController
 
         // Strip characters that are unsafe in filenames across platforms.
         $name = trim((string) preg_replace('#[/\\\\:*?"<>|]+#', ' ', $name));
-        $filename = trim($name.' '.($version ?? '')).'.zip';
 
-        return $url.'?download='.rawurlencode($filename);
+        return trim($name.' '.($version ?? '')).'.zip';
     }
 
     /**
@@ -255,6 +282,7 @@ final class MarketplaceController extends AbstractController
      */
     private function latestDist(array $versions): array
     {
+        $best = [null, null];
         $fallback = [null, null];
 
         foreach ($versions as $version) {
@@ -264,16 +292,22 @@ final class MarketplaceController extends AbstractController
 
             $name = \is_string($version['version'] ?? null) ? $version['version'] : null;
 
-            if (null === $name || !str_starts_with($name, 'dev-')) {
-                return [$version['dist']['url'], $name];
+            if (null === $name || str_starts_with($name, 'dev-')) {
+                if ([null, null] === $fallback) {
+                    $fallback = [$version['dist']['url'], $name];
+                }
+
+                continue;
             }
 
-            if ([null, null] === $fallback) {
-                $fallback = [$version['dist']['url'], $name];
+            // The API does not guarantee any ordering of the versions array, so
+            // compare explicitly to serve the newest stable release.
+            if (null === $best[1] || version_compare(ltrim($name, 'vV'), ltrim($best[1], 'vV'), '>')) {
+                $best = [$version['dist']['url'], $name];
             }
         }
 
-        return $fallback;
+        return null !== $best[0] ? $best : $fallback;
     }
 
     private function toInt(mixed $value, int $default): int

--- a/src/Controller/MarketplaceController.php
+++ b/src/Controller/MarketplaceController.php
@@ -4,14 +4,17 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+use App\Auth0\Auth0User;
 use App\Formatter\LanguageFilterFormatter;
 use App\Formatter\MauticVersionConstraintFormatter;
+use App\Marketplace\Dto\PackageDetail;
 use App\Marketplace\LanguageOptions;
 use App\Marketplace\MarketplaceApiClient;
 use App\Marketplace\MauticVersionsProvider;
 use App\Marketplace\PackageDetailPageContextBuilder;
 use App\Supabase\Exception\SupabaseApiException;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -169,6 +172,94 @@ final class MarketplaceController extends AbstractController
         }
 
         return $this->render('marketplace/detail.html.twig', $page['context'], new Response('', $page['status_code']));
+    }
+
+    public function download(string $package): RedirectResponse
+    {
+        try {
+            $detail = $this->apiClient->getPackage($package);
+        } catch (SupabaseApiException) {
+            $detail = null;
+        }
+
+        if (null === $detail) {
+            throw $this->createNotFoundException(\sprintf('Package "%s" not found.', $package));
+        }
+
+        [$distUrl, $version] = $this->latestDist($detail->versions ?? []);
+
+        if (null === $distUrl) {
+            throw $this->createNotFoundException(\sprintf('Package "%s" has no downloadable archive.', $package));
+        }
+
+        $user = $this->getUser();
+        if ($user instanceof Auth0User) {
+            try {
+                $this->apiClient->recordDownload($detail->name, $version, $user->getUserIdentifier());
+            } catch (SupabaseApiException) {
+                // History is best-effort; never block the download on it.
+            }
+        }
+
+        return new RedirectResponse($this->downloadUrl($detail, $distUrl, $version));
+    }
+
+    /**
+     * Builds the browser-facing archive URL. For marketplace-hosted archives, the
+     * storage ?download parameter names the saved file after the package (e.g.
+     * "Open House Re-engagement 1.0.0.zip") instead of the bare version number.
+     */
+    private function downloadUrl(PackageDetail $detail, string $distUrl, ?string $version): string
+    {
+        $url = $this->apiClient->toPublicStorageUrl($distUrl);
+
+        if (!str_contains($url, '/storage/v1/object/public/')) {
+            // Externally hosted dist — leave the URL untouched.
+            return $url;
+        }
+
+        $name = trim($detail->displayName ?? '');
+        if ('' === $name) {
+            $name = str_contains($detail->name, '/') ? explode('/', $detail->name, 2)[1] : $detail->name;
+        }
+
+        // Strip characters that are unsafe in filenames across platforms.
+        $name = trim((string) preg_replace('#[/\\\\:*?"<>|]+#', ' ', $name));
+        $filename = trim($name.' '.($version ?? '')).'.zip';
+
+        return $url.'?download='.rawurlencode($filename);
+    }
+
+    /**
+     * Resolves the archive URL of the latest downloadable version, preferring
+     * stable versions over dev ones — mirroring how Mautic picks a version
+     * when installing from the marketplace API.
+     *
+     * @param array<mixed> $versions
+     *
+     * @return array{0: ?string, 1: ?string} Dist URL and version string
+     */
+    private function latestDist(array $versions): array
+    {
+        $fallback = [null, null];
+
+        foreach ($versions as $version) {
+            if (!\is_array($version) || !\is_string($version['dist']['url'] ?? null) || '' === $version['dist']['url']) {
+                continue;
+            }
+
+            $name = \is_string($version['version'] ?? null) ? $version['version'] : null;
+
+            if (null === $name || !str_starts_with($name, 'dev-')) {
+                return [$version['dist']['url'], $name];
+            }
+
+            if ([null, null] === $fallback) {
+                $fallback = [$version['dist']['url'], $name];
+            }
+        }
+
+        return $fallback;
     }
 
     private function toInt(mixed $value, int $default): int

--- a/src/Marketplace/MarketplaceApiClient.php
+++ b/src/Marketplace/MarketplaceApiClient.php
@@ -515,7 +515,7 @@ final class MarketplaceApiClient
         ]);
     }
 
-    public function recordDownload(string $packageName, ?string $version, string $auth0UserId): void
+    public function recordDownload(string $packageName, ?string $version, ?string $auth0UserId): void
     {
         $this->supabaseClient->mutate('POST', '/rest/v1/download_history', [
             'auth0_user_id' => $auth0UserId,

--- a/src/Marketplace/MarketplaceApiClient.php
+++ b/src/Marketplace/MarketplaceApiClient.php
@@ -515,6 +515,15 @@ final class MarketplaceApiClient
         ]);
     }
 
+    public function recordDownload(string $packageName, ?string $version, string $auth0UserId): void
+    {
+        $this->supabaseClient->mutate('POST', '/rest/v1/download_history', [
+            'auth0_user_id' => $auth0UserId,
+            'package_name' => $packageName,
+            'package_version' => $version,
+        ]);
+    }
+
     private function toInt(mixed $value): ?int
     {
         if (null === $value || '' === $value) {
@@ -568,12 +577,23 @@ final class MarketplaceApiClient
             return null;
         }
 
-        // Tolerate rows that stored the full storage URL (with the server-side host)
-        // instead of the bucket-relative path: keep only the part after the public
-        // prefix so the browser-facing URL is rebuilt from the public base below.
+        return $this->toPublicStorageUrl($path);
+    }
+
+    /**
+     * Rebuilds a storage object URL (or bucket-relative path) against the browser-facing
+     * storage base. Rows may store URLs with the server-side host (e.g. the in-cluster
+     * Supabase hostname), which browsers can't reach — only the object path is kept and
+     * the public base is prepended.
+     */
+    public function toPublicStorageUrl(string $path): string
+    {
         $marker = '/storage/v1/object/public/';
         if (false !== ($pos = strpos($path, $marker))) {
             $path = substr($path, $pos + \strlen($marker));
+        } elseif (str_starts_with($path, 'http://') || str_starts_with($path, 'https://')) {
+            // Absolute URL outside marketplace storage (e.g. an externally hosted dist) — leave as-is.
+            return $path;
         }
 
         $base = '' !== $this->supabasePublicUrl ? $this->supabasePublicUrl : $this->supabaseBaseUrl;

--- a/src/Marketplace/PackageDownloadArchiveBuilder.php
+++ b/src/Marketplace/PackageDownloadArchiveBuilder.php
@@ -56,15 +56,14 @@ final class PackageDownloadArchiveBuilder
 
         $added = false;
 
-        // Mautic share-flow archives already carry banner/gallery entries; keep
-        // the publisher's originals and only fill in what is missing.
-        if (null !== $detail->bannerURL && [] === preg_grep('#^banner\.#', $entries)) {
-            $added = $this->addImage($zip, $detail->bannerURL, 'banner', $detail->name);
+        // Added images live under assets/ to match the Mautic export layout; legacy root-level entries count as already present.
+        if (null !== $detail->bannerURL && [] === preg_grep('#^(assets/)?banner\.#', $entries)) {
+            $added = $this->addImage($zip, $detail->bannerURL, 'assets/banner', $detail->name);
         }
 
-        if (null !== $detail->gallery && [] === preg_grep('#^gallery/#', $entries)) {
+        if (null !== $detail->gallery && [] === preg_grep('#^(assets/)?gallery/#', $entries)) {
             foreach ($detail->gallery as $index => $image) {
-                $baseName = 'gallery/image_'.($index + 1);
+                $baseName = 'assets/gallery/image_'.($index + 1);
                 if (!$this->addImage($zip, $image['src'], $baseName, $detail->name)) {
                     continue;
                 }

--- a/src/Marketplace/PackageDownloadArchiveBuilder.php
+++ b/src/Marketplace/PackageDownloadArchiveBuilder.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace;
+
+use App\Marketplace\Dto\PackageDetail;
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Rebuilds a package's dist archive with the marketplace-hosted presentation
+ * images (banner + gallery) added, so "Download this package" delivers
+ * everything the publisher attached — not just the files inside the uploaded
+ * ZIP. Wizard uploads store those images as separate storage objects that are
+ * only referenced from the package row, hence the repack at download time.
+ */
+final class PackageDownloadArchiveBuilder
+{
+    private const IMAGE_EXTENSIONS = ['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg'];
+
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * Returns the path of a temporary ZIP ready to stream, or null when there
+     * is nothing to add (no images, images already packed by the Mautic share
+     * flow, or the archive could not be fetched) — callers then fall back to
+     * redirecting to the stored archive.
+     */
+    public function build(PackageDetail $detail, string $archiveUrl): ?string
+    {
+        if (null === $detail->bannerURL && null === $detail->gallery) {
+            return null;
+        }
+
+        $tmpPath = $this->fetchArchive($detail->name, $archiveUrl);
+        if (null === $tmpPath) {
+            return null;
+        }
+
+        $zip = new \ZipArchive();
+        if (true !== $zip->open($tmpPath)) {
+            @unlink($tmpPath);
+
+            return null;
+        }
+
+        $entries = [];
+        for ($i = 0; $i < $zip->numFiles; ++$i) {
+            $entries[] = (string) $zip->getNameIndex($i);
+        }
+
+        $added = false;
+
+        // Mautic share-flow archives already carry banner/gallery entries; keep
+        // the publisher's originals and only fill in what is missing.
+        if (null !== $detail->bannerURL && [] === preg_grep('#^banner\.#', $entries)) {
+            $added = $this->addImage($zip, $detail->bannerURL, 'banner', $detail->name);
+        }
+
+        if (null !== $detail->gallery && [] === preg_grep('#^gallery/#', $entries)) {
+            foreach ($detail->gallery as $index => $image) {
+                $baseName = 'gallery/image_'.($index + 1);
+                if (!$this->addImage($zip, $image['src'], $baseName, $detail->name)) {
+                    continue;
+                }
+
+                $added = true;
+                if ('' !== $image['alt']) {
+                    $zip->addFromString($baseName.'.alt.txt', $image['alt']);
+                }
+            }
+        }
+
+        $zip->close();
+
+        if (!$added) {
+            @unlink($tmpPath);
+
+            return null;
+        }
+
+        return $tmpPath;
+    }
+
+    private function fetchArchive(string $packageName, string $archiveUrl): ?string
+    {
+        try {
+            $contents = $this->httpClient->request('GET', $archiveUrl)->getContent();
+        } catch (\Throwable $exception) {
+            $this->logger->warning('Could not fetch the stored package archive to bundle its images.', [
+                'exception' => $exception,
+                'package' => $packageName,
+                'archive_url' => $archiveUrl,
+            ]);
+
+            return null;
+        }
+
+        $tmpPath = tempnam(sys_get_temp_dir(), 'pkg-download-');
+        if (false === $tmpPath || false === file_put_contents($tmpPath, $contents)) {
+            return null;
+        }
+
+        return $tmpPath;
+    }
+
+    private function addImage(\ZipArchive $zip, string $imageUrl, string $baseName, string $packageName): bool
+    {
+        try {
+            $contents = $this->httpClient->request('GET', $imageUrl)->getContent();
+        } catch (\Throwable $exception) {
+            // A missing image must never block the package download itself.
+            $this->logger->warning('Could not fetch a package image to bundle into the download archive.', [
+                'exception' => $exception,
+                'package' => $packageName,
+                'image_url' => $imageUrl,
+            ]);
+
+            return false;
+        }
+
+        return $zip->addFromString($baseName.'.'.$this->extensionFromUrl($imageUrl), $contents);
+    }
+
+    private function extensionFromUrl(string $url): string
+    {
+        $path = (string) (parse_url($url, \PHP_URL_PATH) ?: '');
+        $extension = strtolower(pathinfo($path, \PATHINFO_EXTENSION));
+
+        return \in_array($extension, self::IMAGE_EXTENSIONS, true) ? $extension : 'png';
+    }
+}

--- a/src/Marketplace/PackageImageUploader.php
+++ b/src/Marketplace/PackageImageUploader.php
@@ -31,7 +31,8 @@ final class PackageImageUploader
         'image/gif' => 'gif',
     ];
 
-    // Mautic packs the banner at the ZIP root as "banner.<ext>" (see CampaignShareService::addImageToZip).
+    // Mautic packs the banner as "assets/banner.<ext>" (see CampaignShareService::addImageToZip);
+    // older share archives used the ZIP root, so both locations are read.
     private const ALLOWED_EXTENSIONS = [
         'png' => 'image/png',
         'jpg' => 'image/jpeg',
@@ -85,6 +86,69 @@ final class PackageImageUploader
         return self::BUCKET.'/'.$objectPath;
     }
 
+    /**
+     * Extracts the gallery images packed in a Mautic-shared ZIP ("assets/gallery/image_N.<ext>",
+     * or the ZIP root for older archives), stores them in marketplace-owned storage and returns
+     * entries for packages.gallery. Alt texts come from the sibling "image_N.alt.txt" files.
+     *
+     * @return list<array{url: string, alt: string}>
+     *
+     * @throws SupabaseApiException
+     */
+    public function uploadGalleryFromZip(string $packageName, string $zipPath): array
+    {
+        $zip = new \ZipArchive();
+        if (true !== $zip->open($zipPath)) {
+            return [];
+        }
+
+        $images = [];
+        try {
+            for ($i = 0; $i < $zip->numFiles; ++$i) {
+                $entry = (string) $zip->getNameIndex($i);
+                if (1 !== preg_match('#^(?:assets/)?gallery/image_(\d+)\.([a-z]+)$#', $entry, $matches)) {
+                    continue;
+                }
+
+                $extension = 'jpeg' === $matches[2] ? 'jpg' : $matches[2];
+                if (!isset(self::ALLOWED_EXTENSIONS[$matches[2]])) {
+                    continue;
+                }
+
+                $contents = $zip->getFromName($entry);
+                if (false === $contents || '' === $contents || \strlen($contents) > self::MAX_BYTES) {
+                    // An unreadable or oversized image shouldn't block the whole publish; skip it.
+                    continue;
+                }
+
+                $alt = $zip->getFromName(substr($entry, 0, -\strlen('.'.$matches[2])).'.alt.txt');
+                $images[(int) $matches[1]] = [
+                    'extension' => $extension,
+                    'contents' => $contents,
+                    'mime' => self::ALLOWED_EXTENSIONS[$matches[2]],
+                    'alt' => \is_string($alt) ? trim($alt) : '',
+                ];
+            }
+        } finally {
+            $zip->close();
+        }
+
+        ksort($images);
+
+        $gallery = [];
+        foreach (array_values($images) as $index => $image) {
+            $objectPath = $this->slugify($packageName).'/gallery/'.$index.'.'.$image['extension'];
+            $this->supabaseClient->uploadStorageObject(self::BUCKET, $objectPath, $image['contents'], $image['mime']);
+
+            $gallery[] = [
+                'url' => self::BUCKET.'/'.$objectPath,
+                'alt' => $image['alt'],
+            ];
+        }
+
+        return $gallery;
+    }
+
     private function upload(string $packageName, UploadedFile $file, string $prefix): string
     {
         $mime = $file->getMimeType() ?? '';
@@ -122,10 +186,12 @@ final class PackageImageUploader
         }
 
         try {
-            foreach (array_keys(self::ALLOWED_EXTENSIONS) as $extension) {
-                $contents = $zip->getFromName('banner.'.$extension);
-                if (false !== $contents && '' !== $contents) {
-                    return [$extension, $contents];
+            foreach (['assets/banner.', 'banner.'] as $prefix) {
+                foreach (array_keys(self::ALLOWED_EXTENSIONS) as $extension) {
+                    $contents = $zip->getFromName($prefix.$extension);
+                    if (false !== $contents && '' !== $contents) {
+                        return [$extension, $contents];
+                    }
                 }
             }
 

--- a/src/Marketplace/PackageSubmitService.php
+++ b/src/Marketplace/PackageSubmitService.php
@@ -78,10 +78,12 @@ final class PackageSubmitService
         $request = $this->requestFromComposer($composerData);
         $zipUrl = $this->zipUploader->upload($request->name, $request->version, $zipPath);
 
-        // Mautic packs the banner inside the shared ZIP, so extract it here instead of from a form field.
+        // Mautic packs the banner and gallery inside the shared ZIP, so extract them here
+        // instead of from form fields.
         $bannerUrl = $this->imageUploader->uploadBannerFromZip($request->name, $zipPath);
+        $gallery = $this->imageUploader->uploadGalleryFromZip($request->name, $zipPath);
 
-        return $this->upsertPackage($composerData, $request, $user, $zipUrl, $bannerUrl, []);
+        return $this->upsertPackage($composerData, $request, $user, $zipUrl, $bannerUrl, $gallery);
     }
 
     /**

--- a/supabase/migrations/20260707120000_download_history_nullable_user.sql
+++ b/supabase/migrations/20260707120000_download_history_nullable_user.sql
@@ -1,0 +1,3 @@
+-- Anonymous (not-logged-in) visitors can download packages too; their history
+-- rows carry no user id, so auth0_user_id must be nullable.
+ALTER TABLE public.download_history ALTER COLUMN auth0_user_id DROP NOT NULL;

--- a/templates/marketplace/detail/section--description.html.twig
+++ b/templates/marketplace/detail/section--description.html.twig
@@ -54,7 +54,7 @@
                 %}
                 {% set ctaHref = isPaidPackage and not app.user
                     ? path('auth_login', { returnTo: app.request.requestUri })
-                    : '#'
+                    : path('marketplace_package_download', { package: package.name })
                 %}
                 {% include 'components/button.html.twig' with {
                     buttons: [{

--- a/tests/Controller/MarketplaceControllerTest.php
+++ b/tests/Controller/MarketplaceControllerTest.php
@@ -71,6 +71,62 @@ final class MarketplaceControllerTest extends WebTestCase
         self::assertSame('mautic/example-plugin', $recorded[0]['package_name']);
     }
 
+    public function testPackageDownloadBundlesBannerAndGalleryImages(): void
+    {
+        $client = self::createClient();
+        $client->request('GET', '/package/mautic/welcome-campaign/download');
+
+        self::assertResponseIsSuccessful();
+        self::assertResponseHeaderSame('content-type', 'application/zip');
+        self::assertStringContainsString(
+            'Welcome Campaign 1.0.1.zip',
+            (string) $client->getResponse()->headers->get('content-disposition'),
+        );
+
+        $names = $this->zipEntryNames($client->getInternalResponse()->getContent());
+
+        self::assertContains('entity_data.json', $names);
+        self::assertContains('composer.json', $names);
+        self::assertContains('banner.png', $names);
+        self::assertContains('gallery/image_1.png', $names);
+        self::assertContains('gallery/image_1.alt.txt', $names);
+    }
+
+    public function testPackageDownloadServesTheNewestVersion(): void
+    {
+        $client = self::createClient();
+        $client->request('GET', '/package/mautic/welcome-campaign/download');
+
+        self::assertResponseIsSuccessful();
+
+        // The mock lists 1.0.0 before 1.0.1; the newest version must win regardless.
+        $recorded = self::getContainer()->get(SupabaseMockHttpClient::class)->recordedDownloads;
+        self::assertCount(1, $recorded);
+        self::assertSame('1.0.1', $recorded[0]['package_version']);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function zipEntryNames(string $zipContents): array
+    {
+        $tmpPath = (string) tempnam(sys_get_temp_dir(), 'test-download-');
+        file_put_contents($tmpPath, $zipContents);
+
+        $zip = new \ZipArchive();
+        self::assertTrue($zip->open($tmpPath), 'The downloaded response is not a readable ZIP archive.');
+
+        $names = [];
+        for ($i = 0; $i < $zip->numFiles; ++$i) {
+            $names[] = (string) $zip->getNameIndex($i);
+        }
+
+        $zip->close();
+        unlink($tmpPath);
+
+        return $names;
+    }
+
     public function testDownloadButtonLinksToDownloadRoute(): void
     {
         $client = self::createClient();

--- a/tests/Controller/MarketplaceControllerTest.php
+++ b/tests/Controller/MarketplaceControllerTest.php
@@ -85,11 +85,13 @@ final class MarketplaceControllerTest extends WebTestCase
 
         $names = $this->zipEntryNames($client->getInternalResponse()->getContent());
 
+        // Images live under assets/ so the archive keeps the Mautic export layout
+        // and the import flow restores them into the media directory.
         self::assertContains('entity_data.json', $names);
         self::assertContains('composer.json', $names);
-        self::assertContains('banner.png', $names);
-        self::assertContains('gallery/image_1.png', $names);
-        self::assertContains('gallery/image_1.alt.txt', $names);
+        self::assertContains('assets/banner.png', $names);
+        self::assertContains('assets/gallery/image_1.png', $names);
+        self::assertContains('assets/gallery/image_1.alt.txt', $names);
     }
 
     public function testPackageDownloadServesTheNewestVersion(): void

--- a/tests/Controller/MarketplaceControllerTest.php
+++ b/tests/Controller/MarketplaceControllerTest.php
@@ -34,6 +34,33 @@ final class MarketplaceControllerTest extends WebTestCase
         self::assertPageTitleContains('Mautic Marketplace');
     }
 
+    public function testPackageDownloadRedirectsToArchive(): void
+    {
+        $client = self::createClient();
+        $client->request('GET', '/package/mautic/example-plugin/download');
+
+        self::assertResponseRedirects('https://storage.example.test/package-media/dist/mautic_example-plugin/1.0.0.zip');
+    }
+
+    public function testPackageDownloadRecordsHistoryForAuthenticatedUsers(): void
+    {
+        $client = self::createClient();
+        $client->loginUser(new Auth0User('auth0|test123', 'Test User', 'test@example.com', null), 'main');
+        $client->request('GET', '/package/mautic/example-plugin/download');
+
+        self::assertResponseRedirects('https://storage.example.test/package-media/dist/mautic_example-plugin/1.0.0.zip');
+    }
+
+    public function testDownloadButtonLinksToDownloadRoute(): void
+    {
+        $client = self::createClient();
+        $client->request('GET', '/package/mautic/example-plugin');
+
+        self::assertResponseIsSuccessful();
+        $href = $client->getCrawler()->filter('#package-cta')->attr('href');
+        self::assertSame('/package/mautic/example-plugin/download', $href);
+    }
+
     public function testPackageUploadPageRedirectsAnonymousUsers(): void
     {
         $client = self::createClient();

--- a/tests/Controller/MarketplaceControllerTest.php
+++ b/tests/Controller/MarketplaceControllerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Controller;
 
 use App\Auth0\Auth0User;
+use App\Tests\Mock\SupabaseMockHttpClient;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 final class MarketplaceControllerTest extends WebTestCase
@@ -49,6 +50,25 @@ final class MarketplaceControllerTest extends WebTestCase
         $client->request('GET', '/package/mautic/example-plugin/download');
 
         self::assertResponseRedirects('https://storage.example.test/package-media/dist/mautic_example-plugin/1.0.0.zip');
+
+        $recorded = self::getContainer()->get(SupabaseMockHttpClient::class)->recordedDownloads;
+        self::assertCount(1, $recorded);
+        self::assertSame('auth0|test123', $recorded[0]['auth0_user_id']);
+        self::assertSame('mautic/example-plugin', $recorded[0]['package_name']);
+        self::assertSame('1.0.0', $recorded[0]['package_version']);
+    }
+
+    public function testPackageDownloadRecordsHistoryForAnonymousUsers(): void
+    {
+        $client = self::createClient();
+        $client->request('GET', '/package/mautic/example-plugin/download');
+
+        self::assertResponseRedirects('https://storage.example.test/package-media/dist/mautic_example-plugin/1.0.0.zip');
+
+        $recorded = self::getContainer()->get(SupabaseMockHttpClient::class)->recordedDownloads;
+        self::assertCount(1, $recorded);
+        self::assertNull($recorded[0]['auth0_user_id']);
+        self::assertSame('mautic/example-plugin', $recorded[0]['package_name']);
     }
 
     public function testDownloadButtonLinksToDownloadRoute(): void

--- a/tests/Marketplace/PackageImageUploaderTest.php
+++ b/tests/Marketplace/PackageImageUploaderTest.php
@@ -58,6 +58,52 @@ final class PackageImageUploaderTest extends KernelTestCase
         self::assertNull($this->uploader->uploadBannerFromZip('testuser/no-banner', $zipPath));
     }
 
+    public function testReadsBannerFromAssetsDirectory(): void
+    {
+        $zipPath = $this->makeZip(['assets/banner.png' => 'png-bytes']);
+
+        $result = $this->uploader->uploadBannerFromZip('testuser/assets-banner', $zipPath);
+
+        self::assertSame('package-media/banners/testuser_assets-banner.png', $result);
+    }
+
+    public function testUploadsGalleryImagesWithAltTexts(): void
+    {
+        $zipPath = $this->makeZip([
+            'assets/gallery/image_1.png' => 'png-bytes',
+            'assets/gallery/image_1.alt.txt' => 'First screenshot',
+            'assets/gallery/image_2.jpg' => 'jpg-bytes',
+        ]);
+
+        $gallery = $this->uploader->uploadGalleryFromZip('testuser/with-gallery', $zipPath);
+
+        self::assertSame([
+            ['url' => 'package-media/testuser/with-gallery/gallery/0.png', 'alt' => 'First screenshot'],
+            ['url' => 'package-media/testuser/with-gallery/gallery/1.jpg', 'alt' => ''],
+        ], $gallery);
+    }
+
+    public function testReadsGalleryFromLegacyZipRoot(): void
+    {
+        $zipPath = $this->makeZip([
+            'gallery/image_1.png' => 'png-bytes',
+            'gallery/image_1.alt.txt' => 'Legacy layout',
+        ]);
+
+        $gallery = $this->uploader->uploadGalleryFromZip('testuser/legacy-gallery', $zipPath);
+
+        self::assertSame([
+            ['url' => 'package-media/testuser/legacy-gallery/gallery/0.png', 'alt' => 'Legacy layout'],
+        ], $gallery);
+    }
+
+    public function testReturnsEmptyGalleryWhenArchiveHasNoImages(): void
+    {
+        $zipPath = $this->makeZip(['composer.json' => '{}', 'entity_data.json' => '[]']);
+
+        self::assertSame([], $this->uploader->uploadGalleryFromZip('testuser/no-gallery', $zipPath));
+    }
+
     /**
      * @param array<string, string> $entries
      */

--- a/tests/Mock/SupabaseMockHttpClient.php
+++ b/tests/Mock/SupabaseMockHttpClient.php
@@ -9,9 +9,24 @@ use Symfony\Component\HttpClient\Response\MockResponse;
 
 final class SupabaseMockHttpClient extends MockHttpClient
 {
+    /**
+     * Bodies POSTed to /rest/v1/download_history, captured so tests can assert
+     * that a download was recorded (and for whom).
+     *
+     * @var list<array<string, mixed>>
+     */
+    public array $recordedDownloads = [];
+
     public function __construct()
     {
-        parent::__construct(static function (string $method, string $url, array $options = []): MockResponse {
+        parent::__construct(function (string $method, string $url, array $options = []): MockResponse {
+            if ('POST' === $method && str_contains($url, '/rest/v1/download_history')) {
+                $decoded = json_decode((string) ($options['body'] ?? ''), true);
+                $this->recordedDownloads[] = \is_array($decoded) ? $decoded : [];
+
+                return new MockResponse('[]', ['http_code' => 201, 'response_headers' => ['content-type' => 'application/json']]);
+            }
+
             if (str_contains($url, '/storage/v1/object/')) {
                 return new MockResponse(
                     json_encode(['Key' => 'package-media/mock-object']),

--- a/tests/Mock/SupabaseMockHttpClient.php
+++ b/tests/Mock/SupabaseMockHttpClient.php
@@ -315,7 +315,12 @@ final class SupabaseMockHttpClient extends MockHttpClient
                 'language' => $pkg['language'],
                 'versions' => [
                     '1.0.0' => [
+                        'version' => '1.0.0',
                         'smv' => $pkg['smv'],
+                        'dist' => [
+                            'type' => 'zip',
+                            'url' => 'https://storage.example.test/package-media/dist/'.str_replace('/', '_', (string) $pkg['name']).'/1.0.0.zip',
+                        ],
                     ],
                 ],
                 'reviews' => [],

--- a/tests/Mock/SupabaseMockHttpClient.php
+++ b/tests/Mock/SupabaseMockHttpClient.php
@@ -27,6 +27,10 @@ final class SupabaseMockHttpClient extends MockHttpClient
                 return new MockResponse('[]', ['http_code' => 201, 'response_headers' => ['content-type' => 'application/json']]);
             }
 
+            if ('GET' === $method && str_contains($url, '/storage/v1/object/public/')) {
+                return self::storageObjectResponse($url);
+            }
+
             if (str_contains($url, '/storage/v1/object/')) {
                 return new MockResponse(
                     json_encode(['Key' => 'package-media/mock-object']),
@@ -343,10 +347,48 @@ final class SupabaseMockHttpClient extends MockHttpClient
             ],
         ];
 
+        if ('mautic/welcome-campaign' === $packageName) {
+            // Marketplace-hosted archive with presentation images and two versions;
+            // 1.0.0 deliberately listed first to prove the newest one is served.
+            $distBase = 'http://127.0.0.1:8000/storage/v1/object/public/package-media/dist/mautic_welcome-campaign/';
+            $data['package']['versions'] = [
+                '1.0.0' => ['version' => '1.0.0', 'smv' => $pkg['smv'], 'dist' => ['type' => 'zip', 'url' => $distBase.'1.0.0.zip']],
+                '1.0.1' => ['version' => '1.0.1', 'smv' => $pkg['smv'], 'dist' => ['type' => 'zip', 'url' => $distBase.'1.0.1.zip']],
+            ];
+            $data['package']['banner_url'] = 'package-media/banners/mautic_welcome-campaign/banner.png';
+            $data['package']['gallery'] = [
+                ['url' => 'package-media/gallery/mautic_welcome-campaign/image_1.png', 'alt' => 'Campaign canvas'],
+            ];
+        }
+
         return new MockResponse(
             json_encode($data),
             ['http_code' => 200, 'response_headers' => ['content-type' => 'application/json']],
         );
+    }
+
+    /**
+     * Serves public storage objects the download flow fetches server-side: a real
+     * ZIP archive for dist objects and raw bytes for banner/gallery images.
+     */
+    private static function storageObjectResponse(string $url): MockResponse
+    {
+        $path = (string) (parse_url($url, \PHP_URL_PATH) ?: '');
+
+        if (str_ends_with($path, '.zip')) {
+            $tmpPath = (string) tempnam(sys_get_temp_dir(), 'mock-dist-');
+            $zip = new \ZipArchive();
+            $zip->open($tmpPath, \ZipArchive::OVERWRITE);
+            $zip->addFromString('entity_data.json', '[{"campaigns": []}]');
+            $zip->addFromString('composer.json', (string) json_encode(['name' => 'mautic/welcome-campaign', 'version' => '1.0.1']));
+            $zip->close();
+            $contents = (string) file_get_contents($tmpPath);
+            @unlink($tmpPath);
+
+            return new MockResponse($contents, ['http_code' => 200, 'response_headers' => ['content-type' => 'application/zip']]);
+        }
+
+        return new MockResponse('mock-image-bytes', ['http_code' => 200, 'response_headers' => ['content-type' => 'image/png']]);
     }
 
     private static function userReviewsResponse(string $url): MockResponse


### PR DESCRIPTION
Add package download flow on the detail page

- New GET /package/{package}/download route redirects to the archive  of the latest stable version (dev- versions only as fallback)
- Marketplace-hosted archives get a download filename based on the  package display name and version instead of the bare version number
- Authenticated downloads are recorded in download_history (best-effort,  never blocks the redirect)
- Detail page CTA now links to the download route instead of "#"