### PR TITLE
[CL-334] Add explicit Data API grants for Supabase public schema objects

### DIFF
--- a/supabase/migrations/20260714120000_explicit_data_api_grants.sql
+++ b/supabase/migrations/20260714120000_explicit_data_api_grants.sql
@@ -1,0 +1,25 @@
+-- Explicit Data API grants for all tables, sequences and RPC functions.
+-- Supabase no longer exposes "public" schema objects to the Data API by
+-- default, so every object the app reads or writes through PostgREST needs
+-- an explicit GRANT. Roles: anon = public reads and RPC calls,
+-- service_role = writes and private reads. "authenticated" is not used.
+
+GRANT USAGE ON SCHEMA public TO anon, service_role;
+
+-- Publicly readable tables (row visibility still governed by RLS policies)
+GRANT SELECT ON TABLE public.packages, public.versions, public.reviews TO anon;
+
+GRANT SELECT, INSERT, UPDATE, DELETE
+  ON TABLE public.packages, public.versions, public.reviews, public.download_history
+  TO service_role;
+
+-- download_history is private: environments provisioned under the old
+-- defaults gave anon/authenticated table access, so revoke it explicitly
+REVOKE ALL ON TABLE public.download_history FROM anon, authenticated;
+
+-- Inserts into SERIAL primary keys need access to the backing sequences
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO service_role;
+
+-- RPC functions are SECURITY INVOKER, so the calling role also needs
+-- EXECUTE on any helper functions they use
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO anon, service_role;

--- a/supabase/migrations/README.md
+++ b/supabase/migrations/README.md
@@ -1,0 +1,41 @@
+# Supabase migrations
+
+## Data API grants are explicit (required)
+
+Since Supabase's Data API change (new projects 2026-05-30, existing projects
+2026-10-30), tables in the `public` schema are **not** exposed to PostgREST
+(`/rest/v1/`) by default. A missing grant surfaces as PostgREST error `42501`
+at runtime.
+
+Every migration that creates a table, sequence, or RPC function must grant
+access explicitly. Roles used by this app:
+
+- `anon` — public reads and RPC calls (`SupabaseClient::query()` / `rpc()`)
+- `service_role` — all writes and private reads (`mutate()` / `queryPrivate()`)
+- `authenticated` — not used; do not grant to it without a reason
+
+Template for a new table:
+
+```sql
+CREATE TABLE public.your_table (...);
+
+ALTER TABLE public.your_table ENABLE ROW LEVEL SECURITY;
+-- add RLS policies as needed
+
+GRANT SELECT ON public.your_table TO anon;                          -- only if publicly readable
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.your_table TO service_role;
+GRANT USAGE, SELECT ON SEQUENCE public.your_table_id_seq TO service_role;  -- for SERIAL PKs
+```
+
+Template for a new RPC function (new name or new signature — `CREATE OR
+REPLACE` of an existing signature keeps its grants):
+
+```sql
+GRANT EXECUTE ON FUNCTION public.your_function(arg_types) TO anon, service_role;
+```
+
+Functions are `SECURITY INVOKER`: helper functions called inside an RPC also
+need `EXECUTE` for the calling role.
+
+The baseline grants for everything existing before this convention live in
+`20260714120000_explicit_data_api_grants.sql`.


### PR DESCRIPTION
Add explicit Data API grants for Supabase public schema objects

Supabase is removing the default grants that expose "public" schema objects to the Data API (PostgREST): new projects since May 30, 2026, existing projects from October 30, 2026. Our migrations relied entirely on those defaults.

- Grant anon SELECT on public tables (packages, versions, reviews) and EXECUTE on RPC functions
- Grant service_role full DML on all tables plus sequence access for  SERIAL inserts
- Revoke legacy anon/authenticated access to the private download_history table (inherited from old defaults)
- Document the GRANT + RLS convention for future migrations