### PR TITLE
Add security headers and input length limits from security review fee…

### DIFF
--- a/src/Controller/MarketplaceController.php
+++ b/src/Controller/MarketplaceController.php
@@ -50,12 +50,16 @@ final class MarketplaceController extends AbstractController
 
     public function index(Request $request): Response
     {
-        $limit = $this->toInt($request->query->get('limit'), 10);
-        $offset = $this->toInt($request->query->get('offset'), 0);
+        // UI page sizes go up to 50; hand-crafted query strings get clamped to the same bounds.
+        $limit = min(max($this->toInt($request->query->get('limit'), 10), 1), 50);
+        $offset = max($this->toInt($request->query->get('offset'), 0), 0);
         $orderBy = (string) $request->query->get('orderby', 'downloads');
         $orderDir = (string) $request->query->get('orderdir', 'desc');
         $type = $request->query->get('type');
         $query = $request->query->get('query');
+        if (\is_string($query)) {
+            $query = mb_substr($query, 0, 100);
+        }
         $mauticVersions = $this->normalizeMauticVersions($request->query->all()['mautic'] ?? null);
         $languages = $this->normalizeLanguages($request->query->all()['language'] ?? null);
         $ratingFilter = $this->normalizeRatingFilter($request->query->get('rating'));

--- a/src/EventSubscriber/SecurityHeadersSubscriber.php
+++ b/src/EventSubscriber/SecurityHeadersSubscriber.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Sets baseline security headers on every response unless already present,
+ * so a controller can still override them.
+ */
+final class SecurityHeadersSubscriber implements EventSubscriberInterface
+{
+    private const HEADERS = [
+        'X-Content-Type-Options' => 'nosniff',
+        'X-Frame-Options' => 'SAMEORIGIN',
+        'Referrer-Policy' => 'strict-origin-when-cross-origin',
+        'Permissions-Policy' => 'camera=(), microphone=(), geolocation=()',
+        'Content-Security-Policy' => "frame-ancestors 'self'",
+    ];
+
+    public static function getSubscribedEvents(): array
+    {
+        return [KernelEvents::RESPONSE => 'onKernelResponse'];
+    }
+
+    public function onKernelResponse(ResponseEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $headers = $event->getResponse()->headers;
+        foreach (self::HEADERS as $name => $value) {
+            if (!$headers->has($name)) {
+                $headers->set($name, $value);
+            }
+        }
+
+        // HSTS only over HTTPS; .htaccess already redirects plain HTTP there.
+        if ($event->getRequest()->isSecure() && !$headers->has('Strict-Transport-Security')) {
+            $headers->set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
+        }
+    }
+}

--- a/src/Marketplace/Dto/ReviewRequest.php
+++ b/src/Marketplace/Dto/ReviewRequest.php
@@ -10,6 +10,7 @@ use Symfony\Component\HttpFoundation\InputBag;
 final class ReviewRequest
 {
     private const MINIMUM_REVIEW_LENGTH = 50;
+    private const MAXIMUM_REVIEW_LENGTH = 5000;
 
     public function __construct(
         public readonly int $rating,
@@ -37,6 +38,10 @@ final class ReviewRequest
 
         if (mb_strlen($review) < self::MINIMUM_REVIEW_LENGTH) {
             throw new ReviewValidationException(\sprintf('Review text must be at least %d characters.', self::MINIMUM_REVIEW_LENGTH));
+        }
+
+        if (mb_strlen($review) > self::MAXIMUM_REVIEW_LENGTH) {
+            throw new ReviewValidationException(\sprintf('Review text must be at most %d characters.', self::MAXIMUM_REVIEW_LENGTH));
         }
 
         return new self($rating, $review);

--- a/src/Marketplace/Dto/SubmitRequest.php
+++ b/src/Marketplace/Dto/SubmitRequest.php
@@ -6,8 +6,14 @@ namespace App\Marketplace\Dto;
 
 use Symfony\Component\Validator\Constraints as Assert;
 
+/**
+ * Size caps in the "mautic_share" group also run against share-flow uploads,
+ * where all metadata comes from the ZIP's composer.json instead of this form.
+ */
 final class SubmitRequest
 {
+    public const SHARE_LIMITS_GROUP = 'mautic_share';
+
     /**
      * @param list<string> $keywords
      * @param list<string> $languages
@@ -20,9 +26,11 @@ final class SubmitRequest
             pattern: '#^[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9](([_.]|-{1,2})?[a-z0-9]+)*$#',
             message: 'Name must be a valid package name (vendor/package).',
         )]
+        #[Assert\Length(max: 255, maxMessage: 'Package name must be at most {{ limit }} characters.', groups: ['Default', self::SHARE_LIMITS_GROUP])]
         public readonly string $name = '',
 
         #[Assert\NotBlank(message: 'Version is required.')]
+        #[Assert\Length(max: 64, maxMessage: 'Version must be at most {{ limit }} characters.', groups: ['Default', self::SHARE_LIMITS_GROUP])]
         public readonly string $version = '',
 
         #[Assert\NotBlank(message: 'Category is required.')]
@@ -30,24 +38,32 @@ final class SubmitRequest
         public readonly string $category = '',
 
         #[Assert\NotBlank(message: 'Headline is required.')]
-        #[Assert\Length(max: 60, maxMessage: 'Headline must be at most {{ limit }} characters.')]
+        #[Assert\Length(max: 60, maxMessage: 'Headline must be at most {{ limit }} characters.', groups: ['Default', self::SHARE_LIMITS_GROUP])]
         public readonly string $headline = '',
 
+        #[Assert\Count(max: 20, maxMessage: 'At most {{ limit }} keywords are allowed.', groups: ['Default', self::SHARE_LIMITS_GROUP])]
+        #[Assert\All([new Assert\Length(max: 50, maxMessage: 'Each keyword must be at most {{ limit }} characters.')], groups: ['Default', self::SHARE_LIMITS_GROUP])]
         public readonly array $keywords = [],
 
         #[Assert\NotBlank(message: 'Description is required.')]
         #[Assert\Length(min: 50, minMessage: 'Description must be at least {{ limit }} characters.')]
+        #[Assert\Length(max: 5000, maxMessage: 'Description must be at most {{ limit }} characters.', groups: ['Default', self::SHARE_LIMITS_GROUP])]
         public readonly string $description = '',
 
+        #[Assert\Count(max: 50, maxMessage: 'At most {{ limit }} languages are allowed.', groups: ['Default', self::SHARE_LIMITS_GROUP])]
+        #[Assert\All([new Assert\Length(max: 20, maxMessage: 'Each language must be at most {{ limit }} characters.')], groups: ['Default', self::SHARE_LIMITS_GROUP])]
         public readonly array $languages = [],
 
         #[Assert\NotBlank(message: 'At least one Mautic version must be selected.')]
+        #[Assert\Count(max: 20, maxMessage: 'At most {{ limit }} Mautic versions are allowed.', groups: ['Default', self::SHARE_LIMITS_GROUP])]
+        #[Assert\All([new Assert\Length(max: 20, maxMessage: 'Each Mautic version must be at most {{ limit }} characters.')], groups: ['Default', self::SHARE_LIMITS_GROUP])]
         public readonly array $works_with = [],
 
         #[Assert\NotBlank(message: 'License type is required.')]
+        #[Assert\Length(max: 64, maxMessage: 'License type must be at most {{ limit }} characters.', groups: ['Default', self::SHARE_LIMITS_GROUP])]
         public readonly string $license_type = '',
 
-        #[Assert\PositiveOrZero(message: 'Price must be zero or greater.')]
+        #[Assert\PositiveOrZero(message: 'Price must be zero or greater.', groups: ['Default', self::SHARE_LIMITS_GROUP])]
         public readonly float $price = 0.0,
 
         #[Assert\IsTrue(message: 'You must accept the ownership and Terms and Conditions.')]
@@ -61,8 +77,12 @@ final class SubmitRequest
         #[Assert\Regex(pattern: '#^https://packagist\.org/#', message: 'Packagist URL must point to packagist.org.')]
         public readonly ?string $packagist_url = null,
 
+        #[Assert\Url(message: 'Documentation URL must be a valid URL.', requireTld: true)]
+        #[Assert\Length(max: 255, maxMessage: 'Documentation URL must be at most {{ limit }} characters.')]
         public readonly ?string $documentation = null,
 
+        #[Assert\Count(max: 10, maxMessage: 'At most {{ limit }} gallery captions are allowed.')]
+        #[Assert\All([new Assert\Length(max: 255, maxMessage: 'Each gallery caption must be at most {{ limit }} characters.')])]
         public readonly array $gallery_alt = [],
     ) {
     }

--- a/src/Marketplace/PackageSubmitService.php
+++ b/src/Marketplace/PackageSubmitService.php
@@ -8,6 +8,7 @@ use App\Auth0\Auth0User;
 use App\Marketplace\Dto\SubmitRequest;
 use App\Marketplace\Exception\SubmitValidationException;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 final class PackageSubmitService
 {
@@ -16,6 +17,7 @@ final class PackageSubmitService
         private readonly ComposerJsonReader $composerReader,
         private readonly PackageImageUploader $imageUploader,
         private readonly PackageZipUploader $zipUploader,
+        private readonly ValidatorInterface $validator,
     ) {
     }
 
@@ -76,6 +78,7 @@ final class PackageSubmitService
         }
 
         $request = $this->requestFromComposer($composerData);
+        $this->assertShareLimits($request);
         $zipUrl = $this->zipUploader->upload($request->name, $request->version, $zipPath);
 
         // Mautic packs the banner and gallery inside the shared ZIP, so extract them here
@@ -97,6 +100,27 @@ final class PackageSubmitService
     public function submitFromFile(string $zipPath, Auth0User $user): array
     {
         return $this->submitFromMauticShare($zipPath, $user);
+    }
+
+    /**
+     * Share uploads skip the form validation in SubmitApiController, so the
+     * size caps from SubmitRequest are enforced here.
+     *
+     * @throws SubmitValidationException
+     */
+    private function assertShareLimits(SubmitRequest $request): void
+    {
+        $violations = $this->validator->validate($request, groups: [SubmitRequest::SHARE_LIMITS_GROUP]);
+        if (0 === $violations->count()) {
+            return;
+        }
+
+        $messages = [];
+        foreach ($violations as $violation) {
+            $messages[] = (string) $violation->getMessage();
+        }
+
+        throw new SubmitValidationException(implode(' ', array_unique($messages)));
     }
 
     /**

--- a/tests/Controller/Api/MauticUploadApiControllerTest.php
+++ b/tests/Controller/Api/MauticUploadApiControllerTest.php
@@ -102,6 +102,31 @@ final class MauticUploadApiControllerTest extends WebTestCase
         self::assertStringContainsString('missing a vendor name', $data['error']);
     }
 
+    public function testUploadWithOversizedMetadataIsRejected(): void
+    {
+        $client = self::createClient();
+        $client->loginUser(new Auth0User('auth0|test123', 'Test User', 'test@example.com', null), 'main');
+
+        $this->zipPath = PackageZipFactory::create([
+            'name' => 'testuser/test-campaign',
+            'description' => 'A test campaign for the marketplace.',
+            'type' => 'mautic-resource',
+            'version' => '1.0.0',
+            'extra' => ['mautic' => [
+                'minimum-version' => '5.0',
+                'headline' => str_repeat('x', 61),
+            ]],
+        ]);
+
+        $client->request('POST', '/api/package/mautic-upload', files: [
+            'package' => new UploadedFile($this->zipPath, 'campaign.zip', 'application/zip', test: true),
+        ]);
+
+        self::assertResponseStatusCodeSame(400);
+        $data = json_decode((string) $client->getResponse()->getContent(), true);
+        self::assertStringContainsString('Headline must be at most 60 characters', $data['error']);
+    }
+
     public function testUploadWithoutComposerJsonIsRejected(): void
     {
         $client = self::createClient();

--- a/tests/EventSubscriber/SecurityHeadersSubscriberTest.php
+++ b/tests/EventSubscriber/SecurityHeadersSubscriberTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EventSubscriber;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class SecurityHeadersSubscriberTest extends WebTestCase
+{
+    public function testResponsesCarrySecurityHeaders(): void
+    {
+        $client = self::createClient();
+        $client->request('GET', '/');
+
+        self::assertResponseIsSuccessful();
+
+        $headers = $client->getResponse()->headers;
+        self::assertSame('nosniff', $headers->get('X-Content-Type-Options'));
+        self::assertSame('SAMEORIGIN', $headers->get('X-Frame-Options'));
+        self::assertSame('strict-origin-when-cross-origin', $headers->get('Referrer-Policy'));
+        self::assertSame('camera=(), microphone=(), geolocation=()', $headers->get('Permissions-Policy'));
+        self::assertSame("frame-ancestors 'self'", $headers->get('Content-Security-Policy'));
+    }
+
+    public function testHstsIsOnlySentOverHttps(): void
+    {
+        $client = self::createClient();
+
+        $client->request('GET', '/');
+        self::assertFalse($client->getResponse()->headers->has('Strict-Transport-Security'));
+
+        $client->request('GET', 'https://localhost/');
+        self::assertSame('max-age=31536000; includeSubDomains', $client->getResponse()->headers->get('Strict-Transport-Security'));
+    }
+}


### PR DESCRIPTION
Enforce input length limits and add security headers from security review

- Add SecurityHeadersSubscriber setting X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy, CSP frame-ancestors and HSTS on every response
- Cap all user-supplied fields in SubmitRequest (description, version, license,  keyword/language/version lists, documentation URL) and review body length
- Validate Mautic share uploads against the same size caps via a new  "mautic_share" validation group — this path previously skipped validation entirely
- Clamp browse paging (limit 1-50, offset >= 0) and search query length
- Cover headers and oversized share metadata with tests; drop stale tests/.gitkeep