### PR TITLE
[CL-337] Sanitize package metadata to prevent stored XSS

### DIFF
--- a/src/Marketplace/MetadataSanitizer.php
+++ b/src/Marketplace/MetadataSanitizer.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace;
+
+/**
+ * Strips HTML from short, plain-text package metadata before it is persisted.
+ *
+ * Package metadata (display name, headline, keywords, versions, gallery captions…)
+ * is never meant to contain markup, but it reaches templates that render some of it
+ * with |raw or by string concatenation into HTML attributes. Sanitising on input is
+ * the primary defence against stored XSS from both the upload form and an uploaded
+ * composer.json; output escaping (Twig autoescape / |e) is the second layer.
+ *
+ * Note: free-text description is intentionally NOT handled here. It is rendered
+ * through the CommonMark converter with html_input=escape, which already neutralises
+ * markup, and stripping tags would corrupt legitimate markdown.
+ */
+final class MetadataSanitizer
+{
+    /**
+     * Remove any HTML tags and collapse surrounding whitespace.
+     */
+    public function text(?string $value): string
+    {
+        if (null === $value) {
+            return '';
+        }
+
+        // strip_tags removes complete tags but leaves stray angle brackets from
+        // malformed markup (e.g. an unmatched `">`). These short metadata fields
+        // never legitimately contain `<`/`>`, so drop any that survive.
+        return trim(str_replace(['<', '>'], '', strip_tags($value)));
+    }
+
+    /**
+     * Sanitise every entry of a list of strings, dropping any that become empty.
+     *
+     * @param list<string> $values
+     *
+     * @return list<string>
+     */
+    public function textList(array $values): array
+    {
+        $sanitized = [];
+        foreach ($values as $value) {
+            $clean = $this->text($value);
+            if ('' !== $clean) {
+                $sanitized[] = $clean;
+            }
+        }
+
+        return $sanitized;
+    }
+}

--- a/src/Marketplace/PackageSubmitService.php
+++ b/src/Marketplace/PackageSubmitService.php
@@ -18,6 +18,7 @@ final class PackageSubmitService
         private readonly PackageImageUploader $imageUploader,
         private readonly PackageZipUploader $zipUploader,
         private readonly ValidatorInterface $validator,
+        private readonly MetadataSanitizer $sanitizer,
     ) {
     }
 
@@ -221,19 +222,28 @@ final class PackageSubmitService
             $status = 'pending';
         }
 
-        $maintainerName = $user->getName() ?? $user->getEmail() ?? 'Anonymous';
+        $maintainerName = $this->sanitizer->text($user->getName() ?? $user->getEmail() ?? 'Anonymous');
+        if ('' === $maintainerName) {
+            $maintainerName = 'Anonymous';
+        }
+
+        $displayName = $composerData['extra']['mautic']['display-name'] ?? null;
+        $displayName = \is_string($displayName) ? $this->sanitizer->text($displayName) : '';
+        if ('' === $displayName) {
+            $displayName = $this->toDisplayName($packageName);
+        }
 
         $packageData = [
             'name' => $packageName,
-            'displayname' => $composerData['extra']['mautic']['display-name'] ?? $this->toDisplayName($packageName),
+            'displayname' => $displayName,
             'description' => $request->description,
             'type' => $request->category,
             'time' => (new \DateTimeImmutable())->format('c'),
             'maintainers' => [['name' => $maintainerName]],
             'auth0_user_id' => $user->getUserIdentifier(),
-            'headline' => $request->headline,
-            'languages' => $request->languages,
-            'works_with' => $request->works_with,
+            'headline' => $this->sanitizer->text($request->headline),
+            'languages' => $this->sanitizer->textList($request->languages),
+            'works_with' => $this->sanitizer->textList($request->works_with),
             'price' => $request->price,
             'license_type' => $request->license_type,
             'github_url' => $request->github_url,
@@ -256,7 +266,13 @@ final class PackageSubmitService
         }
 
         if ([] !== $gallery) {
-            $packageData['gallery'] = $gallery;
+            $packageData['gallery'] = array_map(
+                fn (array $image): array => [
+                    'url' => $image['url'],
+                    'alt' => $this->sanitizer->text($image['alt']),
+                ],
+                $gallery,
+            );
         }
 
         if ($created) {
@@ -277,12 +293,14 @@ final class PackageSubmitService
 
         $smv = $this->composerReader->extractMauticVersion($composerData);
 
+        $sanitizedVersion = $this->sanitizer->text($request->version);
+
         $versionData = [
             'package_name' => $packageName,
-            'version' => $request->version,
-            'version_normalized' => $this->composerReader->normalizeVersion($request->version),
+            'version' => $sanitizedVersion,
+            'version_normalized' => $this->composerReader->normalizeVersion($sanitizedVersion),
             'description' => $request->description,
-            'keywords' => $request->keywords,
+            'keywords' => $this->sanitizer->textList($request->keywords),
             'license' => $composerData['license'] ?? [$request->license_type],
             'authors' => $composerData['authors'] ?? null,
             'type' => $request->category,
@@ -297,7 +315,7 @@ final class PackageSubmitService
 
         return [
             'package_name' => $packageName,
-            'version' => $request->version,
+            'version' => $sanitizedVersion,
             'status' => $status,
             'created' => $created,
         ];

--- a/src/Marketplace/PackageSubmitService.php
+++ b/src/Marketplace/PackageSubmitService.php
@@ -233,6 +233,13 @@ final class PackageSubmitService
             $displayName = $this->toDisplayName($packageName);
         }
 
+        // works_with may legitimately be empty in the share flow, but a non-empty
+        // submission must not be emptied by sanitization (markup-only entries).
+        $worksWith = $this->sanitizer->textList($request->works_with);
+        if ([] === $worksWith && [] !== $request->works_with) {
+            throw new SubmitValidationException('Supported Mautic versions must contain plain text, not just HTML markup.');
+        }
+
         $packageData = [
             'name' => $packageName,
             'displayname' => $displayName,
@@ -241,9 +248,9 @@ final class PackageSubmitService
             'time' => (new \DateTimeImmutable())->format('c'),
             'maintainers' => [['name' => $maintainerName]],
             'auth0_user_id' => $user->getUserIdentifier(),
-            'headline' => $this->sanitizer->text($request->headline),
+            'headline' => $this->requirePlainText($request->headline, 'Headline'),
             'languages' => $this->sanitizer->textList($request->languages),
-            'works_with' => $this->sanitizer->textList($request->works_with),
+            'works_with' => $worksWith,
             'price' => $request->price,
             'license_type' => $request->license_type,
             'github_url' => $request->github_url,
@@ -293,7 +300,7 @@ final class PackageSubmitService
 
         $smv = $this->composerReader->extractMauticVersion($composerData);
 
-        $sanitizedVersion = $this->sanitizer->text($request->version);
+        $sanitizedVersion = $this->requirePlainText($request->version, 'Version');
 
         $versionData = [
             'package_name' => $packageName,
@@ -319,6 +326,24 @@ final class PackageSubmitService
             'status' => $status,
             'created' => $created,
         ];
+    }
+
+    /**
+     * Sanitize a field whose NotBlank guarantee must survive sanitization:
+     * input that was non-blank but consisted only of markup is rejected
+     * instead of being silently stored as an empty string. Fields that are
+     * allowed to be empty (share flow) pass through untouched.
+     *
+     * @throws SubmitValidationException
+     */
+    private function requirePlainText(string $value, string $field): string
+    {
+        $clean = $this->sanitizer->text($value);
+        if ('' === $clean && '' !== trim($value)) {
+            throw new SubmitValidationException(\sprintf('%s must contain plain text, not just HTML markup.', $field));
+        }
+
+        return $clean;
     }
 
     private function toDisplayName(string $packageName): string

--- a/templates/components/tags.html.twig
+++ b/templates/components/tags.html.twig
@@ -84,7 +84,7 @@
                     <i class="{{ icon }}" aria-hidden="true" focusable="false"></i>
                 {% endif %}
                 <span aria-hidden="true">
-                    {{ truncated_label|raw }}
+                    {{ truncated_label }}
                 </span>
                 <button type="button" class="label-close" onclick="{{ dismissible_onclick|default('') }}" aria-label="{{ 'mautic.core.dismiss'|trans }}" title="{{ 'mautic.core.dismiss'|trans }}" data-bs-toggle="tooltip" data-bs-placement="top">
                     <i class="ri-close-line" aria-hidden="true" focusable="false"></i>
@@ -102,7 +102,7 @@
                         data-bs-placement="top"
                     {% endif %}
                 >
-                    {{ truncated_label|raw }}
+                    {{ truncated_label }}
                 </span>
 
             {% elseif type == 'selectable' %}
@@ -118,7 +118,7 @@
                     {% if icon %}
                         <i class="{{ icon }}" aria-hidden="true" focusable="false"></i>
                     {% endif %}
-                    <span aria-hidden="true">{{ truncated_label|raw }}</span>
+                    <span aria-hidden="true">{{ truncated_label }}</span>
                 </button>
 
             {% else %}
@@ -126,7 +126,7 @@
                     <i class="{{ icon }}" aria-hidden="true" focusable="false"></i>
                 {% endif %}
                 <span aria-hidden="true" {% if label_tooltip %} title="{{ label_tooltip }}"{% endif %}>
-                    {{ truncated_label|raw }}
+                    {{ truncated_label }}
                 </span>
             {% endif %}
         {% endif %}

--- a/templates/marketplace/detail/section--gallery.html.twig
+++ b/templates/marketplace/detail/section--gallery.html.twig
@@ -30,7 +30,7 @@
                     centered: true,
                     size: 'lg',
                     body_class: 'text-center',
-                    body: '<img src="' ~ image.src ~ '" alt="' ~ image.alt ~ '" class="img-fluid" style="max-height: 75vh;">'
+                    body: '<img src="' ~ image.src|e('html_attr') ~ '" alt="' ~ image.alt|e('html_attr') ~ '" class="img-fluid" style="max-height: 75vh;">'
                 } only %}
             {% endfor %}
         </div>

--- a/tests/Marketplace/MetadataSanitizerTest.php
+++ b/tests/Marketplace/MetadataSanitizerTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Marketplace;
+
+use App\Marketplace\MetadataSanitizer;
+use PHPUnit\Framework\TestCase;
+
+final class MetadataSanitizerTest extends TestCase
+{
+    private MetadataSanitizer $sanitizer;
+
+    protected function setUp(): void
+    {
+        $this->sanitizer = new MetadataSanitizer();
+    }
+
+    public function testStripsHtmlTagsFromText(): void
+    {
+        self::assertSame('XSS test 1', $this->sanitizer->text('XSS test 1<img src onerror=alert(2)>'));
+    }
+
+    public function testRemovesTagsAndStrayAngleBrackets(): void
+    {
+        // strip_tags removes the complete <img> tag; the stray `">` residue from the
+        // malformed attribute break must not survive with its angle bracket.
+        $clean = $this->sanitizer->text('2.0.1<img src onerror=alert(13)>" onerror=alert(14)>');
+        self::assertStringNotContainsString('<', $clean);
+        self::assertStringNotContainsString('>', $clean);
+        self::assertStringStartsWith('2.0.1', $clean);
+    }
+
+    public function testKeepsInterTagTextAsInertPlainText(): void
+    {
+        // strip_tags keeps text between tags; it is harmless once output is escaped.
+        self::assertSame('alert(1)', $this->sanitizer->text('<script>alert(1)</script>'));
+    }
+
+    public function testTrimsSurroundingWhitespace(): void
+    {
+        self::assertSame('hello', $this->sanitizer->text("  <b>hello</b>\n"));
+    }
+
+    public function testNullBecomesEmptyString(): void
+    {
+        self::assertSame('', $this->sanitizer->text(null));
+    }
+
+    public function testKeepsPlainText(): void
+    {
+        self::assertSame('7.0', $this->sanitizer->text('7.0'));
+    }
+
+    public function testTextListSanitizesEachEntryAndDropsEmpties(): void
+    {
+        self::assertSame(
+            ['en', '7.0'],
+            $this->sanitizer->textList([
+                'en<img src onerror=alert(6)>',
+                '<img src onerror=alert(1)>',
+                '7.0',
+            ]),
+        );
+    }
+}


### PR DESCRIPTION
Upload-form and composer.json metadata was stored unfiltered and rendered unescaped (pentest #11, #12).

- Add MetadataSanitizer and apply it in PackageSubmitService to display   name, headline, keywords, languages, works-with, version, gallery  captions and maintainer name (all submit paths). Description untouched (CommonMark escapes it).
- Escape at the sinks: tags.html.twig drops |raw; gallery modal escapes  alt/src via e('html_attr').
- Add MetadataSanitizer unit tests.