### PR TITLE
Fix incomplete logout: expire session cookie in the browser

### DIFF
--- a/src/Controller/AuthController.php
+++ b/src/Controller/AuthController.php
@@ -119,19 +119,35 @@ final class AuthController extends AbstractController
     {
         $returnTo = $this->urlGenerator->generate('marketplace_homepage', [], UrlGeneratorInterface::ABSOLUTE_URL);
 
+        // Drop the authenticated token and destroy the server-side session so the
+        // old session id can no longer be replayed.
         $this->tokenStorage->setToken(null);
 
+        $sessionName = null;
         if ($request->hasSession()) {
-            $request->getSession()->invalidate();
+            $session = $request->getSession();
+            $sessionName = $session->getName();
+            $session->invalidate();
         }
 
         try {
-            return new RedirectResponse($this->auth0Client->createLogoutUrl($returnTo));
+            // Redirect through Auth0 /v2/logout so the Auth0 SSO session is
+            // terminated too; otherwise the next login silently re-authenticates
+            // from the still-valid Auth0 session cookie.
+            $response = new RedirectResponse($this->auth0Client->createLogoutUrl($returnTo));
         } catch (Auth0AuthenticationException $exception) {
             $this->addFlash('error', $exception->getMessage());
 
-            return $this->redirectToRoute('marketplace_homepage');
+            $response = $this->redirectToRoute('marketplace_homepage');
         }
+
+        // Explicitly expire the session cookie so the browser drops it instead of
+        // keeping a stale one alongside the invalidated server session.
+        if (null !== $sessionName) {
+            $response->headers->clearCookie($sessionName);
+        }
+
+        return $response;
     }
 
     private function sanitizeReturnTo(mixed $returnTo): string

--- a/tests/Controller/AuthControllerTest.php
+++ b/tests/Controller/AuthControllerTest.php
@@ -100,6 +100,18 @@ final class AuthControllerTest extends WebTestCase
         self::assertResponseRedirects();
         self::assertStringContainsString('https://test.auth0.com/v2/logout', (string) $client->getResponse()->headers->get('Location'));
 
+        // The session cookie must be actively expired on the logout response so the
+        // browser drops it rather than replaying the invalidated session.
+        $sessionName = self::getContainer()->get('session.factory')->createSession()->getName();
+        $cleared = null;
+        foreach ($client->getResponse()->headers->getCookies() as $cookie) {
+            if ($cookie->getName() === $sessionName) {
+                $cleared = $cookie;
+            }
+        }
+        self::assertNotNull($cleared, 'Logout response must set a cookie for the session name.');
+        self::assertTrue($cleared->isCleared(), 'Logout must expire the session cookie in the browser.');
+
         $client->request('GET', '/browse');
 
         self::assertResponseIsSuccessful();


### PR DESCRIPTION
Fix incomplete logout: expire session cookie in the browser

Logout cleared the security token and invalidated the server-side session but left the session cookie in the browser, so the client kept a stale cookie alongside the destroyed session.