### PR TITLE
Addresses findings from the Radically Open Security penetration test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,11 @@ RUN printf '%s\n' \
   'post_max_size = 64M' \
   > /usr/local/etc/php/conf.d/upload-limits.ini
 
+# X-Powered-By passes straight through the proxy, so drop it at the source.
+RUN printf '%s\n' \
+  'expose_php = Off' \
+  > /usr/local/etc/php/conf.d/security.ini
+
 ENV APP_ENV=prod
 ENV APP_DEBUG=0
 
@@ -63,12 +68,11 @@ RUN printf '%s\n' \
 # (rejected inside <Directory>), so it's appended directly to apache2.conf.
 RUN echo 'AllowEncodedSlashes NoDecode' >> /etc/apache2/apache2.conf
 
-# Allow campaign ZIP uploads up to the marketplace's 50MB cap (PackageZipUploader::MAX_BYTES).
-# A few MB of headroom on post_max_size covers multipart form overhead.
+# Must follow Debian's conf-enabled include, which defaults to ServerTokens OS.
 RUN printf '%s\n' \
-  'upload_max_filesize = 60M' \
-  'post_max_size = 64M' \
-  > /usr/local/etc/php/conf.d/upload-limits.ini
+  'ServerTokens Prod' \
+  'ServerSignature Off' \
+  >> /etc/apache2/apache2.conf
 
 RUN chown -R www-data:www-data /var/www/html/var
 

--- a/assets/publish-upload.js
+++ b/assets/publish-upload.js
@@ -1,3 +1,7 @@
+// Mirrors PackageZipUploader::MAX_BYTES. The API rejects anything bigger anyway; this saves
+// the popup from streaming a huge archive across first.
+const MAX_ARCHIVE_BYTES = 50 * 1024 * 1024;
+
 function initPublishUpload() {
     const container = document.getElementById('publish-upload-container');
 
@@ -59,6 +63,12 @@ function initPublishUpload() {
         const { archive, filename } = event.data;
         if (!(archive instanceof Blob) || archive.size === 0) {
             showError("Mautic didn't send a valid campaign archive. Close this window and try again from Mautic.");
+            return;
+        }
+
+        if (archive.size > MAX_ARCHIVE_BYTES) {
+            showError('This campaign archive is ' + formatBytes(archive.size) + ', which is over the '
+                + formatBytes(MAX_ARCHIVE_BYTES) + ' limit. Remove some assets in Mautic and share it again.');
             return;
         }
 

--- a/assets/publish-upload.js
+++ b/assets/publish-upload.js
@@ -1,7 +1,3 @@
-// Mirrors PackageZipUploader::MAX_BYTES. The API rejects anything bigger anyway; this saves
-// the popup from streaming a huge archive across first.
-const MAX_ARCHIVE_BYTES = 50 * 1024 * 1024;
-
 function initPublishUpload() {
     const container = document.getElementById('publish-upload-container');
 
@@ -16,6 +12,10 @@ function initPublishUpload() {
     const sizeEl = document.getElementById('publish-upload-size');
     const errorEl = document.getElementById('publish-upload-error');
     const successEl = document.getElementById('publish-upload-success');
+
+    // Rendered from PackageZipUploader::MAX_BYTES, so the limit lives in one place. The API
+    // rejects anything bigger regardless; this saves streaming a huge archive across first.
+    const maxArchiveBytes = Number(container.dataset.maxBytes) || Infinity;
 
     // State held in the popup until the user confirms upload. We store the trusted
     // origin from the postMessage event (browser-set, can't be spoofed by page JS).
@@ -66,9 +66,9 @@ function initPublishUpload() {
             return;
         }
 
-        if (archive.size > MAX_ARCHIVE_BYTES) {
+        if (archive.size > maxArchiveBytes) {
             showError('This campaign archive is ' + formatBytes(archive.size) + ', which is over the '
-                + formatBytes(MAX_ARCHIVE_BYTES) + ' limit. Remove some assets in Mautic and share it again.');
+                + formatBytes(maxArchiveBytes) + ' limit. Remove some assets in Mautic and share it again.');
             return;
         }
 

--- a/assets/upload-wizard.js
+++ b/assets/upload-wizard.js
@@ -19,6 +19,30 @@ import { validateForm } from './validation.js';
 const GENERIC_ERROR = "Something went wrong while publishing. Please try again, or contact support if it keeps happening.";
 const SESSION_EXPIRED_ERROR = "Your session has expired. Please log in again in another tab, then come back and submit once more.";
 
+// Mirrors PackageZipUploader::MAX_BYTES and PackageImageUploader::MAX_BYTES. The server still
+// enforces both; this just saves pushing a file over the wire to be told it was too big.
+const MAX_ZIP_BYTES = 50 * 1024 * 1024;
+const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+
+function formatMegabytes(bytes) {
+    return Math.round(bytes / 1024 / 1024) + 'MB';
+}
+
+/**
+ * @param {Array<{file: File, limit: number, label: string}>} candidates
+ * @returns {string|null} Message for the first file over its limit, or null if all fit.
+ */
+function oversizedFileError(candidates) {
+    const tooBig = candidates.find(({ file, limit }) => file && file.size > limit);
+
+    if (!tooBig) {
+        return null;
+    }
+
+    return 'The ' + tooBig.label + ' "' + tooBig.file.name + '" is ' + formatMegabytes(tooBig.file.size)
+        + '. The maximum is ' + formatMegabytes(tooBig.limit) + '.';
+}
+
 function initUploadWizard() {
     const forms = Array.from(document.querySelectorAll('form[data-wizard-step]'))
         .sort((a, b) => Number(a.dataset.wizardStep) - Number(b.dataset.wizardStep));
@@ -108,6 +132,14 @@ function initUploadWizard() {
             return;
         }
 
+        const oversized = oversizedFileError([
+            { file: fileInput.files[0], limit: MAX_ZIP_BYTES, label: 'ZIP file' },
+        ]);
+        if (oversized) {
+            showStatus(form, 'error', oversized);
+            return;
+        }
+
         const restore = busy(submitter, 'Checking package...');
         hideStatus(form);
 
@@ -170,6 +202,17 @@ function initUploadWizard() {
             // The ZIP lives in step 1; bounce back if it was never chosen.
             showStatus(form, 'error', 'Please choose a package ZIP in step 1 before submitting.');
             goTo(1);
+            return;
+        }
+
+        const oversized = oversizedFileError([
+            { file: fileInput.files[0], limit: MAX_ZIP_BYTES, label: 'ZIP file' },
+            { file: fileById('package-banner-image'), limit: MAX_IMAGE_BYTES, label: 'banner image' },
+            ...Array.from(document.getElementById('package-gallery-images')?.files || [])
+                .map((file) => ({ file, limit: MAX_IMAGE_BYTES, label: 'gallery image' })),
+        ]);
+        if (oversized) {
+            showStatus(form, 'error', oversized);
             return;
         }
 

--- a/assets/upload-wizard.js
+++ b/assets/upload-wizard.js
@@ -19,13 +19,21 @@ import { validateForm } from './validation.js';
 const GENERIC_ERROR = "Something went wrong while publishing. Please try again, or contact support if it keeps happening.";
 const SESSION_EXPIRED_ERROR = "Your session has expired. Please log in again in another tab, then come back and submit once more.";
 
-// Mirrors PackageZipUploader::MAX_BYTES and PackageImageUploader::MAX_BYTES. The server still
-// enforces both; this just saves pushing a file over the wire to be told it was too big.
-const MAX_ZIP_BYTES = 50 * 1024 * 1024;
-const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
-
 function formatMegabytes(bytes) {
     return Math.round(bytes / 1024 / 1024) + 'MB';
+}
+
+/**
+ * The limit each input renders in data-max-bytes, straight from the PHP constant the server
+ * enforces. Absent or unparseable means no client-side check — the server still rejects.
+ *
+ * @param {HTMLInputElement|null} input
+ * @returns {number} Byte limit, or Infinity when the input declares none.
+ */
+function declaredMaxBytes(input) {
+    const limit = Number(input?.dataset.maxBytes);
+
+    return Number.isFinite(limit) && limit > 0 ? limit : Infinity;
 }
 
 /**
@@ -133,7 +141,7 @@ function initUploadWizard() {
         }
 
         const oversized = oversizedFileError([
-            { file: fileInput.files[0], limit: MAX_ZIP_BYTES, label: 'ZIP file' },
+            { file: fileInput.files[0], limit: declaredMaxBytes(fileInput), label: 'ZIP file' },
         ]);
         if (oversized) {
             showStatus(form, 'error', oversized);
@@ -205,11 +213,14 @@ function initUploadWizard() {
             return;
         }
 
+        const bannerInput  = document.getElementById('package-banner-image');
+        const galleryInput = document.getElementById('package-gallery-images');
+
         const oversized = oversizedFileError([
-            { file: fileInput.files[0], limit: MAX_ZIP_BYTES, label: 'ZIP file' },
-            { file: fileById('package-banner-image'), limit: MAX_IMAGE_BYTES, label: 'banner image' },
-            ...Array.from(document.getElementById('package-gallery-images')?.files || [])
-                .map((file) => ({ file, limit: MAX_IMAGE_BYTES, label: 'gallery image' })),
+            { file: fileInput.files[0], limit: declaredMaxBytes(fileInput), label: 'ZIP file' },
+            { file: fileById('package-banner-image'), limit: declaredMaxBytes(bannerInput), label: 'banner image' },
+            ...Array.from(galleryInput?.files || [])
+                .map((file) => ({ file, limit: declaredMaxBytes(galleryInput), label: 'gallery image' })),
         ]);
         if (oversized) {
             showStatus(form, 'error', oversized);

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": ">=8.4",
         "ext-ctype": "*",
         "ext-iconv": "*",
-        "league/commonmark": "^2.8.2",
+        "league/commonmark": "^2.9.1",
         "symfony/asset": "7.4.*",
         "symfony/asset-mapper": "7.4.*",
         "symfony/console": "7.4.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "15b52dd34d653c82a5001dc94999f4e6",
+    "content-hash": "8164c7d7d71f947330857ef85d332594",
     "packages": [
         {
             "name": "composer/semver",
@@ -160,16 +160,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.8.2",
+            "version": "2.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "59fb075d2101740c337c7216e3f32b36c204218b"
+                "reference": "73cb188c785abfa7a7bec73487148202968274c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/59fb075d2101740c337c7216e3f32b36c204218b",
-                "reference": "59fb075d2101740c337c7216e3f32b36c204218b",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/73cb188c785abfa7a7bec73487148202968274c6",
+                "reference": "73cb188c785abfa7a7bec73487148202968274c6",
                 "shasum": ""
             },
             "require": {
@@ -191,8 +191,8 @@
                 "github/gfm": "0.29.0",
                 "michelf/php-markdown": "^1.4 || ^2.0",
                 "nyholm/psr7": "^1.5",
-                "phpstan/phpstan": "^1.8.2",
-                "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0",
+                "phpstan/phpstan": "^2.0.0",
+                "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0 || ^12.0.0 || ^13.0.0",
                 "scrutinizer/ocular": "^1.8.1",
                 "symfony/finder": "^5.3 | ^6.0 | ^7.0 || ^8.0",
                 "symfony/process": "^5.4 | ^6.0 | ^7.0 || ^8.0",
@@ -206,7 +206,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.9-dev"
+                    "dev-main": "2.10-dev"
                 }
             },
             "autoload": {
@@ -263,7 +263,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-19T13:16:38+00:00"
+            "time": "2026-08-09T14:10:38+00:00"
         },
         {
             "name": "league/config",
@@ -9319,5 +9319,5 @@
         "ext-iconv": "*"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -85,3 +85,15 @@ marketplace_detail:
     controller: App\Controller\MarketplaceController::detail
     requirements:
         package: .+
+
+# Public read API for Mautic instances. Versioned because released Mautic versions pin
+# to it, and deliberately not under /api/package, which security.yaml gates behind ROLE_USER.
+api_registry_packages:
+    path: /api/registry/v1/packages
+    controller: App\Controller\Api\RegistryApiController::packages
+    methods: [GET]
+
+api_registry_package:
+    path: /api/registry/v1/packages/{vendor}/{package}
+    controller: App\Controller\Api\RegistryApiController::package
+    methods: [GET]

--- a/scripts/deploy/remote_deploy.sh
+++ b/scripts/deploy/remote_deploy.sh
@@ -80,6 +80,13 @@ if [[ -n "${PROD_DOMAIN}" || -n "${STAGING_DOMAIN}" ]]; then
     ${SUDO} apt-get install -y --no-install-recommends certbot python3-certbot-nginx
   fi
 
+  # At http level so it covers both server blocks and survives the site config being
+  # rewritten on each deploy. proxy_hide_header also covers pre-expose_php images.
+  printf '%s\n' \
+    'server_tokens off;' \
+    'proxy_hide_header X-Powered-By;' \
+    | ${SUDO} tee /etc/nginx/conf.d/security.conf >/dev/null
+
   {
     if [[ -n "${PROD_DOMAIN}" ]]; then
       cat <<NGINX_CONF

--- a/src/Controller/Api/RegistryApiController.php
+++ b/src/Controller/Api/RegistryApiController.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Api;
+
+use App\Supabase\Exception\SupabaseApiException;
+use App\Supabase\SupabaseClient;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * The public read API a Mautic instance browses the marketplace through.
+ *
+ * Mautic used to call Supabase directly, which meant every install shipped a copy of the
+ * anon key. Going through here keeps the credential on this side, and gives the two a
+ * stable contract instead of one pinned to Supabase's function names.
+ */
+final class RegistryApiController extends AbstractController
+{
+    private const DEFAULT_LIMIT = 30;
+
+    private const MAX_LIMIT = 100;
+
+    public function __construct(
+        private readonly SupabaseClient $supabaseClient,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function packages(Request $request): JsonResponse
+    {
+        $limit = min(self::MAX_LIMIT, max(1, $request->query->getInt('limit', self::DEFAULT_LIMIT)));
+        $page = max(1, $request->query->getInt('page', 1));
+
+        $params = [
+            '_limit' => $limit,
+            '_offset' => ($page - 1) * $limit,
+        ];
+
+        $query = trim($request->query->getString('query'));
+        if ('' !== $query) {
+            $params['_query'] = $query;
+        }
+
+        try {
+            $data = $this->supabaseClient->rpc('/rest/v1/rpc/get_view', $params);
+        } catch (SupabaseApiException $e) {
+            return $this->unavailable('list packages', $e);
+        }
+
+        return $this->json($this->normalizeList(\is_array($data) ? $data : []));
+    }
+
+    public function package(string $vendor, string $package): JsonResponse
+    {
+        try {
+            $data = $this->supabaseClient->query('GET', '/rest/v1/rpc/get_pack', [
+                'packag_name' => $vendor.'/'.$package,
+            ]);
+        } catch (SupabaseApiException $e) {
+            return $this->unavailable('read package', $e);
+        }
+
+        $row = \is_array($data) ? ($data['package'] ?? null) : null;
+
+        if (!\is_array($row) || !isset($row['name'])) {
+            return $this->json(['error' => 'Package not found.'], Response::HTTP_NOT_FOUND);
+        }
+
+        return $this->json(['package' => $row]);
+    }
+
+    /**
+     * PostgREST returns the row either on its own or wrapped in a single-element list, so pin
+     * the shape here rather than leaving every consumer to cope with both.
+     *
+     * @param array<mixed> $data
+     *
+     * @return array{total: int, results: list<mixed>}
+     */
+    private function normalizeList(array $data): array
+    {
+        $payload = \array_key_exists('results', $data) ? $data : ($data[0] ?? []);
+
+        if (!\is_array($payload)) {
+            return ['total' => 0, 'results' => []];
+        }
+
+        $results = $payload['results'] ?? [];
+
+        return [
+            'total' => (int) ($payload['total'] ?? 0),
+            'results' => \is_array($results) ? array_values($results) : [],
+        ];
+    }
+
+    private function unavailable(string $action, SupabaseApiException $e): JsonResponse
+    {
+        $this->logger->error(\sprintf('Registry API failed to %s.', $action), ['exception' => $e]);
+
+        return $this->json(
+            ['error' => 'The marketplace is temporarily unavailable. Please try again shortly.'],
+            Response::HTTP_BAD_GATEWAY,
+        );
+    }
+}

--- a/src/EventSubscriber/SecurityHeadersSubscriber.php
+++ b/src/EventSubscriber/SecurityHeadersSubscriber.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\EventSubscriber;
 
+use App\Security\CspNonceGenerator;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -19,8 +20,12 @@ final class SecurityHeadersSubscriber implements EventSubscriberInterface
         'X-Frame-Options' => 'SAMEORIGIN',
         'Referrer-Policy' => 'strict-origin-when-cross-origin',
         'Permissions-Policy' => 'camera=(), microphone=(), geolocation=()',
-        'Content-Security-Policy' => "frame-ancestors 'self'",
     ];
+
+    public function __construct(
+        private readonly CspNonceGenerator $nonceGenerator,
+    ) {
+    }
 
     public static function getSubscribedEvents(): array
     {
@@ -40,9 +45,42 @@ final class SecurityHeadersSubscriber implements EventSubscriberInterface
             }
         }
 
+        if (!$headers->has('Content-Security-Policy')) {
+            $headers->set('Content-Security-Policy', $this->contentSecurityPolicy());
+        }
+
         // HSTS only over HTTPS; .htaccess already redirects plain HTTP there.
         if ($event->getRequest()->isSecure() && !$headers->has('Strict-Transport-Security')) {
             $headers->set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
         }
+    }
+
+    /**
+     * script-src does the real work here: an injected string stays inert even if it slips past
+     * escaping, since only same-origin files and this request's nonce may run.
+     *
+     * style-src still needs 'unsafe-inline' — the Carbon components set custom properties per
+     * element (`style="--card-group--cards-in-row: 3"`), which no nonce or hash can cover. An
+     * accepted gap; CSS injection is a much smaller prize than script injection.
+     */
+    private function contentSecurityPolicy(): string
+    {
+        return implode('; ', [
+            "default-src 'self'",
+            // ga.jspm.io is AssetMapper's es-module-shims fallback for browsers without import
+            // maps. Symfony pins it with an SRI hash, so the host can't swap in other code.
+            \sprintf("script-src 'self' 'nonce-%s' https://ga.jspm.io", $this->nonceGenerator->nonce()),
+            "style-src 'self' 'unsafe-inline'",
+            // Banners come from Supabase storage and avatars from whatever host Auth0 hands back,
+            // so we can't enumerate the image origins.
+            "img-src 'self' data: https:",
+            "font-src 'self' data:",
+            // The browser only calls this app; Supabase is reached server-side.
+            "connect-src 'self'",
+            "form-action 'self'",
+            "frame-ancestors 'self'",
+            "base-uri 'self'",
+            "object-src 'none'",
+        ]);
     }
 }

--- a/src/Marketplace/Dto/ReviewRequest.php
+++ b/src/Marketplace/Dto/ReviewRequest.php
@@ -26,7 +26,11 @@ final class ReviewRequest
     public static function fromPayload(InputBag $payload): self
     {
         $rating = $payload->getInt('rating');
-        $review = trim($payload->getString('review'));
+
+        // Reviews are plain text, so strip tags on the way in — a consumer that trusts our API
+        // response shouldn't inherit a payload from us. Lone angle brackets stay ("1 < 2" is
+        // ordinary prose, and Twig escapes it anyway).
+        $review = trim(strip_tags($payload->getString('review')));
 
         if ($rating < 1 || $rating > 5) {
             throw new ReviewValidationException('Rating must be between 1 and 5.');

--- a/src/Marketplace/Dto/SubmitRequest.php
+++ b/src/Marketplace/Dto/SubmitRequest.php
@@ -31,6 +31,13 @@ final class SubmitRequest
 
         #[Assert\NotBlank(message: 'Version is required.')]
         #[Assert\Length(max: 64, maxMessage: 'Version must be at most {{ limit }} characters.', groups: ['Default', self::SHARE_LIMITS_GROUP])]
+        // Compared with version_compare downstream, so an arbitrary string is both a correctness
+        // and an injection problem. In the share group too, where it comes from composer.json.
+        #[Assert\Regex(
+            pattern: '#^(dev-[A-Za-z0-9._/-]+|v?\d+(\.\d+){0,3}(-[A-Za-z0-9.-]+)?(\+[A-Za-z0-9.-]+)?)$#',
+            message: 'Version must look like 1.2.3, v1.2.3-beta.1 or dev-main.',
+            groups: ['Default', self::SHARE_LIMITS_GROUP],
+        )]
         public readonly string $version = '',
 
         #[Assert\NotBlank(message: 'Category is required.')]
@@ -46,7 +53,9 @@ final class SubmitRequest
         public readonly array $keywords = [],
 
         #[Assert\NotBlank(message: 'Description is required.')]
-        #[Assert\Length(min: 50, minMessage: 'Description must be at least {{ limit }} characters.')]
+        // Matches the 150 the upload form asks for and enforces client-side; the two used to
+        // disagree, so a submission bypassing the form was held to a laxer rule than the UI stated.
+        #[Assert\Length(min: 150, minMessage: 'Description must be at least {{ limit }} characters.')]
         #[Assert\Length(max: 5000, maxMessage: 'Description must be at most {{ limit }} characters.', groups: ['Default', self::SHARE_LIMITS_GROUP])]
         public readonly string $description = '',
 

--- a/src/Marketplace/PackageImageUploader.php
+++ b/src/Marketplace/PackageImageUploader.php
@@ -43,6 +43,11 @@ final class PackageImageUploader
 
     private const MAX_BYTES = 5 * 1024 * 1024;
 
+    // Bytes alone don't bound an image: a decompression bomb sits well under 5MB and still
+    // decodes to billions of pixels. We stream the bytes straight to storage without decoding
+    // them, but whoever renders them later does.
+    private const MAX_PIXELS = 25_000_000;
+
     public function __construct(
         private readonly SupabaseClient $supabaseClient,
     ) {
@@ -128,6 +133,11 @@ final class PackageImageUploader
                     continue;
                 }
 
+                if (!$this->hasSaneDimensions($contents)) {
+                    // Same as an oversized entry: skip the image, don't fail the import.
+                    continue;
+                }
+
                 $alt = $zip->getFromName(substr($entry, 0, -\strlen('.'.$matches[2])).'.alt.txt');
                 $images[(int) $matches[1]] = [
                     'extension' => $matches[2],
@@ -172,6 +182,10 @@ final class PackageImageUploader
             throw new SubmitValidationException('Failed to read uploaded image.');
         }
 
+        if (!$this->hasSaneDimensions($contents)) {
+            throw new SubmitValidationException(\sprintf('Image dimensions are too large. The maximum is %d megapixels (width × height).', self::MAX_PIXELS / 1_000_000));
+        }
+
         $extension = self::MIME_EXTENSIONS[$mime];
         $objectPath = $this->slugify($packageName).'/'.$prefix.'.'.$extension;
 
@@ -207,7 +221,7 @@ final class PackageImageUploader
                     }
 
                     $contents = $zip->getFromName($prefix.$extension);
-                    if (false !== $contents && '' !== $contents) {
+                    if (false !== $contents && '' !== $contents && $this->hasSaneDimensions($contents)) {
                         return [$extension, $contents];
                     }
                 }
@@ -217,6 +231,22 @@ final class PackageImageUploader
         } finally {
             $zip->close();
         }
+    }
+
+    /**
+     * Reads only the header, so this costs nothing. Unrecognised bytes are rejected too — an
+     * upload's declared MIME type comes from the client, so this doubles as a content sniff.
+     */
+    private function hasSaneDimensions(string $contents): bool
+    {
+        $size = @getimagesizefromstring($contents);
+        if (false === $size) {
+            return false;
+        }
+
+        [$width, $height] = $size;
+
+        return $width > 0 && $height > 0 && $width * $height <= self::MAX_PIXELS;
     }
 
     private function slugify(string $packageName): string

--- a/src/Marketplace/PackageImageUploader.php
+++ b/src/Marketplace/PackageImageUploader.php
@@ -41,7 +41,8 @@ final class PackageImageUploader
         'webp' => 'image/webp',
     ];
 
-    private const MAX_BYTES = 5 * 1024 * 1024;
+    // Public so the upload form can render it as the client-side limit and the two stay in step.
+    public const MAX_BYTES = 5 * 1024 * 1024;
 
     // Bytes alone don't bound an image: a decompression bomb sits well under 5MB and still
     // decodes to billions of pixels. We stream the bytes straight to storage without decoding

--- a/src/Security/CspNonceGenerator.php
+++ b/src/Security/CspNonceGenerator.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * The nonce that links the CSP header to the inline <script> tags we emit.
+ *
+ * Cached on the Request, not on this service: the service is shared across requests, and a
+ * reused nonce is no better than 'unsafe-inline'.
+ */
+final class CspNonceGenerator
+{
+    private const REQUEST_ATTRIBUTE = '_csp_nonce';
+
+    public function __construct(
+        private readonly RequestStack $requestStack,
+    ) {
+    }
+
+    public function nonce(): string
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        if (null === $request) {
+            // CLI, or a template rendered outside HTTP: nobody will read the header either.
+            return $this->generate();
+        }
+
+        $nonce = $request->attributes->get(self::REQUEST_ATTRIBUTE);
+        if (!\is_string($nonce)) {
+            $nonce = $this->generate();
+            $request->attributes->set(self::REQUEST_ATTRIBUTE, $nonce);
+        }
+
+        return $nonce;
+    }
+
+    private function generate(): string
+    {
+        return base64_encode(random_bytes(16));
+    }
+}

--- a/src/Twig/Extension/CspExtension.php
+++ b/src/Twig/Extension/CspExtension.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Twig\Extension;
+
+use App\Security\CspNonceGenerator;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+final class CspExtension extends AbstractExtension
+{
+    public function __construct(
+        private readonly CspNonceGenerator $nonceGenerator,
+    ) {
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            // Deliberately not html-safe: it goes in an attribute and should be escaped.
+            new TwigFunction('csp_nonce', [$this->nonceGenerator, 'nonce']),
+        ];
+    }
+}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -5,7 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}Mautic Marketplace{% endblock %}</title>
     <script src="{{ asset('assets/marketplace.js') }}" defer data-turbo-track="reload"></script>
-    {% block importmap %}{{ importmap('app') }}{% endblock %}
+    {# Inline scripts, so they need the nonce from SecurityHeadersSubscriber's CSP header. #}
+    {% block importmap %}{{ importmap('app', { nonce: csp_nonce() }) }}{% endblock %}
 </head>
 <body>
       {% include 'components/uishell.html.twig' with {

--- a/templates/components/button.html.twig
+++ b/templates/components/button.html.twig
@@ -67,7 +67,9 @@
         </a>
     {% else %}
         {% set button_type = button.attributes.type is defined ? button.attributes.type : (button.onclick is defined and button.onclick != '' ? 'button' : 'submit') %}
-        <button type="{{ button_type }}" aria-label="{{ button.label|trans }}" class="{{ button_classes|join(' ') }}" onclick="{{ button.onclick is defined ? button.onclick|e('html_attr') : '' }}"{{ custom_attributes|raw }}>
+        {# Only emit onclick when a caller supplies one — an empty handler still counts as an
+           inline script under the CSP. #}
+        <button type="{{ button_type }}" aria-label="{{ button.label|trans }}" class="{{ button_classes|join(' ') }}"{% if button.onclick is defined and button.onclick != '' %} onclick="{{ button.onclick|e('html_attr') }}"{% endif %}{{ custom_attributes|raw }}>
             {% if button.icon is defined %}
                 <i class="{{ button.icon }}" aria-hidden="true" focusable="false" {{ icon_attributes|raw }}></i>
             {% endif %}

--- a/templates/components/tags.html.twig
+++ b/templates/components/tags.html.twig
@@ -86,7 +86,7 @@
                 <span aria-hidden="true">
                     {{ truncated_label }}
                 </span>
-                <button type="button" class="label-close" onclick="{{ dismissible_onclick|default('') }}" aria-label="{{ 'mautic.core.dismiss'|trans }}" title="{{ 'mautic.core.dismiss'|trans }}" data-bs-toggle="tooltip" data-bs-placement="top">
+                <button type="button" class="label-close"{% if dismissible_onclick|default('') != '' %} onclick="{{ dismissible_onclick }}"{% endif %} aria-label="{{ 'mautic.core.dismiss'|trans }}" title="{{ 'mautic.core.dismiss'|trans }}" data-bs-toggle="tooltip" data-bs-placement="top">
                     <i class="ri-close-line" aria-hidden="true" focusable="false"></i>
                 </button>
 

--- a/templates/components/tags.html.twig
+++ b/templates/components/tags.html.twig
@@ -86,7 +86,7 @@
                 <span aria-hidden="true">
                     {{ truncated_label }}
                 </span>
-                <button type="button" class="label-close"{% if dismissible_onclick|default('') != '' %} onclick="{{ dismissible_onclick }}"{% endif %} aria-label="{{ 'mautic.core.dismiss'|trans }}" title="{{ 'mautic.core.dismiss'|trans }}" data-bs-toggle="tooltip" data-bs-placement="top">
+                <button type="button" class="label-close"{% if dismissible_onclick|default('') != '' %} onclick="{{ dismissible_onclick|e('html_attr') }}"{% endif %} aria-label="{{ 'mautic.core.dismiss'|trans }}" title="{{ 'mautic.core.dismiss'|trans }}" data-bs-toggle="tooltip" data-bs-placement="top">
                     <i class="ri-close-line" aria-hidden="true" focusable="false"></i>
                 </button>
 

--- a/templates/components/uishell.html.twig
+++ b/templates/components/uishell.html.twig
@@ -4,7 +4,7 @@
     {% endif %}
 
     {% if Header.children.HeaderMenuButton is defined %}
-    <button aria-expanded="false" aria-label="{{ Header.children.HeaderMenuButton.ariaLabel|trans }}" class="header__action header__menu-trigger header__menu-toggle header__menu-toggle__hidden {{ Header.children.HeaderMenuButton.className|default('') }}" title="{{ Header.children.HeaderMenuButton.ariaLabel|trans }}" type="button" onclick="{{ Header.children.HeaderMenuButton.onClick|default('') }}">
+    <button aria-expanded="false" aria-label="{{ Header.children.HeaderMenuButton.ariaLabel|trans }}" class="header__action header__menu-trigger header__menu-toggle header__menu-toggle__hidden {{ Header.children.HeaderMenuButton.className|default('') }}" title="{{ Header.children.HeaderMenuButton.ariaLabel|trans }}" type="button"{% if Header.children.HeaderMenuButton.onClick|default('') != '' %} onclick="{{ Header.children.HeaderMenuButton.onClick }}"{% endif %}>
         {% if Header.children.HeaderMenuButton.renderMenuIcon is defined %}
         <i class="{{ Header.children.HeaderMenuButton.renderMenuIcon }} fs-16"></i>
         {% endif %}

--- a/templates/components/uishell.html.twig
+++ b/templates/components/uishell.html.twig
@@ -4,7 +4,7 @@
     {% endif %}
 
     {% if Header.children.HeaderMenuButton is defined %}
-    <button aria-expanded="false" aria-label="{{ Header.children.HeaderMenuButton.ariaLabel|trans }}" class="header__action header__menu-trigger header__menu-toggle header__menu-toggle__hidden {{ Header.children.HeaderMenuButton.className|default('') }}" title="{{ Header.children.HeaderMenuButton.ariaLabel|trans }}" type="button"{% if Header.children.HeaderMenuButton.onClick|default('') != '' %} onclick="{{ Header.children.HeaderMenuButton.onClick }}"{% endif %}>
+    <button aria-expanded="false" aria-label="{{ Header.children.HeaderMenuButton.ariaLabel|trans }}" class="header__action header__menu-trigger header__menu-toggle header__menu-toggle__hidden {{ Header.children.HeaderMenuButton.className|default('') }}" title="{{ Header.children.HeaderMenuButton.ariaLabel|trans }}" type="button"{% if Header.children.HeaderMenuButton.onClick|default('') != '' %} onclick="{{ Header.children.HeaderMenuButton.onClick|e('html_attr') }}"{% endif %}>
         {% if Header.children.HeaderMenuButton.renderMenuIcon is defined %}
         <i class="{{ Header.children.HeaderMenuButton.renderMenuIcon }} fs-16"></i>
         {% endif %}

--- a/templates/marketplace/upload/package/step--details.html.twig
+++ b/templates/marketplace/upload/package/step--details.html.twig
@@ -89,7 +89,8 @@
                 label: 'mautic.marketplace.upload.package.field.banner_image.label'|trans,
                 helpText: 'mautic.marketplace.upload.package.field.banner_image.help'|trans,
                 attributes: {
-                    accept: 'image/png,image/jpeg,image/webp'
+                    accept: 'image/png,image/jpeg,image/webp',
+                    'data-max-bytes': constant('App\\Marketplace\\PackageImageUploader::MAX_BYTES')
                 },
                 validation: {
                     rules: ['fileTypes(png,jpg,jpeg,webp,image/png,image/jpeg,image/webp)'],
@@ -109,7 +110,8 @@
                     helpText: 'mautic.marketplace.upload.package.field.gallery_images.help'|trans,
                     attributes: {
                         accept: 'image/png,image/jpeg,image/webp',
-                        multiple: 'multiple'
+                        multiple: 'multiple',
+                        'data-max-bytes': constant('App\\Marketplace\\PackageImageUploader::MAX_BYTES')
                     },
                     validation: {
                         rules: ['fileTypes(png,jpg,jpeg,webp,image/png,image/jpeg,image/webp)', 'maxFiles(2)'],

--- a/templates/marketplace/upload/package/step--upload.html.twig
+++ b/templates/marketplace/upload/package/step--upload.html.twig
@@ -14,7 +14,8 @@
         wrapperClass: 'd-flex flex-column',
         helpText: 'mautic.marketplace.upload.package.field.package_zip.help'|trans,
         attributes: {
-            accept: '.zip,application/zip'
+            accept: '.zip,application/zip',
+            'data-max-bytes': constant('App\\Marketplace\\PackageZipUploader::MAX_BYTES')
         },
         validation: {
             rules: ['fileTypes(zip,application/zip,application/x-zip-compressed)'],

--- a/templates/publish/upload.html.twig
+++ b/templates/publish/upload.html.twig
@@ -3,7 +3,7 @@
 {% block title %}Publish to Marketplace{% endblock %}
 
 {% block body %}
-<section id="publish-upload-container">
+<section id="publish-upload-container" data-max-bytes="{{ constant('App\\Marketplace\\PackageZipUploader::MAX_BYTES') }}">
 
     <div class="publish-upload-hero" style="background: #4e5e9e; padding: 56px 0 48px;">
         <div class="container">

--- a/tests/Controller/Api/RegistryApiControllerTest.php
+++ b/tests/Controller/Api/RegistryApiControllerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller\Api;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class RegistryApiControllerTest extends WebTestCase
+{
+    /**
+     * A Mautic instance calls this with no credentials of its own, so it has to work while
+     * logged out. That is the whole point of the endpoint.
+     */
+    public function testPackageListIsPublic(): void
+    {
+        $client = self::createClient();
+        $client->request('GET', '/api/registry/v1/packages');
+
+        self::assertResponseIsSuccessful();
+        self::assertResponseHeaderSame('content-type', 'application/json');
+
+        $payload = $this->decode($client);
+        self::assertArrayHasKey('total', $payload);
+        self::assertArrayHasKey('results', $payload);
+        self::assertIsInt($payload['total']);
+        self::assertIsArray($payload['results']);
+    }
+
+    public function testPackageDetailIsPublic(): void
+    {
+        $client = self::createClient();
+        $client->request('GET', '/api/registry/v1/packages/mautic/example-plugin');
+
+        self::assertResponseIsSuccessful();
+
+        $payload = $this->decode($client);
+        self::assertSame('mautic/example-plugin', $payload['package']['name']);
+    }
+
+    /**
+     * Left unbounded, a caller could ask for the whole table in one request.
+     */
+    public function testLimitIsCapped(): void
+    {
+        $client = self::createClient();
+        $client->request('GET', '/api/registry/v1/packages?limit=5000');
+
+        self::assertResponseIsSuccessful();
+        self::assertLessThanOrEqual(100, \count($this->decode($client)['results']));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decode(\Symfony\Bundle\FrameworkBundle\KernelBrowser $client): array
+    {
+        return json_decode((string) $client->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+    }
+}

--- a/tests/Controller/Api/SubmitApiControllerTest.php
+++ b/tests/Controller/Api/SubmitApiControllerTest.php
@@ -164,6 +164,39 @@ final class SubmitApiControllerTest extends WebTestCase
         self::assertResponseStatusCodeSame(422);
     }
 
+    public function testSubmitRejectsAVersionThatIsNotAVersion(): void
+    {
+        // Versions are compared and prefix-matched downstream, so an arbitrary string has to be
+        // refused outright rather than sanitised into something meaningless.
+        $client = self::createClient();
+        $client->loginUser(new Auth0User('auth0|test123', 'Test User', 'test@example.com', null), 'main');
+
+        $fields = $this->validFormFields();
+        $fields['version'] = '2.0.1<img src onerror=alert(1)>';
+
+        $client->request('POST', '/api/package/submit', $fields, ['zip' => $this->validZipUpload()]);
+
+        self::assertResponseStatusCodeSame(422);
+        $payload = json_decode((string) $client->getResponse()->getContent(), true);
+        self::assertContains('version', array_column($payload['violations'], 'field'));
+    }
+
+    public function testSubmitRejectsADescriptionShorterThanTheFormDemands(): void
+    {
+        $client = self::createClient();
+        $client->loginUser(new Auth0User('auth0|test123', 'Test User', 'test@example.com', null), 'main');
+
+        // Comfortably over the old 50-character rule, still under the 150 the form asks for.
+        $fields = $this->validFormFields();
+        $fields['description'] = str_repeat('Too short. ', 8);
+
+        $client->request('POST', '/api/package/submit', $fields, ['zip' => $this->validZipUpload()]);
+
+        self::assertResponseStatusCodeSame(422);
+        $payload = json_decode((string) $client->getResponse()->getContent(), true);
+        self::assertContains('description', array_column($payload['violations'], 'field'));
+    }
+
     public function testSubmitRejectsPublishingOverAnotherUsersPackage(): void
     {
         $client = self::createClient();
@@ -191,7 +224,7 @@ final class SubmitApiControllerTest extends WebTestCase
             'category' => 'mautic-resource',
             'headline' => 'A short headline',
             'keywords' => ['test', 'campaign'],
-            'description' => str_repeat('Detailed description for the package. ', 3),
+            'description' => str_repeat('Detailed description for the package. ', 5),
             'languages' => ['en'],
             'works_with' => ['5.2', '5.1'],
             'license_type' => 'MIT',

--- a/tests/Controller/MarketplaceControllerTest.php
+++ b/tests/Controller/MarketplaceControllerTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Tests\Controller;
 
 use App\Auth0\Auth0User;
+use App\Marketplace\PackageImageUploader;
+use App\Marketplace\PackageZipUploader;
 use App\Tests\Mock\SupabaseMockHttpClient;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
@@ -158,6 +160,34 @@ final class MarketplaceControllerTest extends WebTestCase
         self::assertSelectorExists('form.needs-validation[novalidate]');
         self::assertSelectorExists('#package-zip[required][data-validation-field]');
         self::assertPageTitleContains('Upload package');
+    }
+
+    /**
+     * The wizard reads its client-side limits off these attributes, so they have to carry the
+     * same numbers the server enforces — otherwise the two drift apart silently.
+     */
+    public function testUploadInputsCarryTheServerSideSizeLimits(): void
+    {
+        $client = self::createClient();
+        $client->loginUser(new Auth0User('auth0|test123', 'Test User', 'test@example.com', null), 'main');
+
+        $client->request('GET', '/upload/package');
+        self::assertSame(
+            (string) PackageZipUploader::MAX_BYTES,
+            $client->getCrawler()->filter('#package-zip')->attr('data-max-bytes'),
+        );
+
+        $client->request('GET', '/upload/package?step=3');
+        $crawler = $client->getCrawler();
+
+        self::assertSame(
+            (string) PackageImageUploader::MAX_BYTES,
+            $crawler->filter('#package-banner-image')->attr('data-max-bytes'),
+        );
+        self::assertSame(
+            (string) PackageImageUploader::MAX_BYTES,
+            $crawler->filter('#package-gallery-images')->attr('data-max-bytes'),
+        );
     }
 
     public function testPackageUploadBasicsStepRendersValidationAttributes(): void

--- a/tests/EventSubscriber/SecurityHeadersSubscriberTest.php
+++ b/tests/EventSubscriber/SecurityHeadersSubscriberTest.php
@@ -20,7 +20,63 @@ final class SecurityHeadersSubscriberTest extends WebTestCase
         self::assertSame('SAMEORIGIN', $headers->get('X-Frame-Options'));
         self::assertSame('strict-origin-when-cross-origin', $headers->get('Referrer-Policy'));
         self::assertSame('camera=(), microphone=(), geolocation=()', $headers->get('Permissions-Policy'));
-        self::assertSame("frame-ancestors 'self'", $headers->get('Content-Security-Policy'));
+
+        $csp = (string) $headers->get('Content-Security-Policy');
+        self::assertStringContainsString("default-src 'self'", $csp);
+        self::assertStringContainsString("object-src 'none'", $csp);
+        self::assertStringContainsString("base-uri 'self'", $csp);
+        self::assertStringContainsString("frame-ancestors 'self'", $csp);
+    }
+
+    /**
+     * A mismatch between header and markup takes the page's whole JavaScript down.
+     */
+    public function testInlineScriptsCarryTheNonceFromTheCspHeader(): void
+    {
+        $client = self::createClient();
+        $crawler = $client->request('GET', '/');
+
+        self::assertResponseIsSuccessful();
+
+        $csp = (string) $client->getResponse()->headers->get('Content-Security-Policy');
+        self::assertSame(1, preg_match("/script-src [^;]*'nonce-([^']+)'/", $csp, $matches), 'script-src must carry a nonce.');
+
+        $nonce = $matches[1];
+        $importMap = $crawler->filter('script[type="importmap"]');
+
+        self::assertCount(1, $importMap);
+        self::assertSame($nonce, $importMap->attr('nonce'));
+    }
+
+    public function testEachResponseGetsItsOwnNonce(): void
+    {
+        $client = self::createClient();
+
+        $client->request('GET', '/');
+        $first = (string) $client->getResponse()->headers->get('Content-Security-Policy');
+
+        $client->request('GET', '/');
+        $second = (string) $client->getResponse()->headers->get('Content-Security-Policy');
+
+        self::assertNotSame($first, $second, 'A reused nonce is no better than no nonce.');
+    }
+
+    /**
+     * A redirect is the first thing an unauthenticated visitor hits on the upload flow.
+     *
+     * The one uncovered case is Symfony's own exception page, where ErrorListener::removeCspHeader()
+     * strips the header so it can render. That's behind the debug flag — dev and test only.
+     */
+    public function testNonSuccessfulResponsesAreAlsoCovered(): void
+    {
+        $client = self::createClient();
+        $client->request('GET', '/upload/package');
+
+        self::assertResponseStatusCodeSame(302);
+        self::assertStringContainsString(
+            "default-src 'self'",
+            (string) $client->getResponse()->headers->get('Content-Security-Policy'),
+        );
     }
 
     public function testHstsIsOnlySentOverHttps(): void

--- a/tests/Marketplace/Dto/ReviewRequestTest.php
+++ b/tests/Marketplace/Dto/ReviewRequestTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Marketplace\Dto;
+
+use App\Marketplace\Dto\ReviewRequest;
+use App\Marketplace\Exception\ReviewValidationException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\InputBag;
+
+final class ReviewRequestTest extends TestCase
+{
+    public function testStripsHtmlFromReviewText(): void
+    {
+        $request = ReviewRequest::fromPayload($this->payload(
+            '<img src onerror=alert(1)> This template saved me a lot of setup time and works well.',
+        ));
+
+        self::assertSame('This template saved me a lot of setup time and works well.', $request->review);
+    }
+
+    public function testKeepsAngleBracketsThatAreNotMarkup(): void
+    {
+        $text = 'Works fine as long as your list has < 500 contacts, otherwise it slows down a lot.';
+
+        self::assertSame($text, ReviewRequest::fromPayload($this->payload($text))->review);
+    }
+
+    /**
+     * Length is checked after stripping, so markup can't pad a review up to the minimum.
+     */
+    public function testRejectsTextThatOnlyReachesTheMinimumThroughMarkup(): void
+    {
+        $this->expectException(ReviewValidationException::class);
+
+        ReviewRequest::fromPayload($this->payload('<div class="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">Nice</div>'));
+    }
+
+    public function testRejectsTextThatIsNothingButMarkup(): void
+    {
+        $this->expectException(ReviewValidationException::class);
+
+        ReviewRequest::fromPayload($this->payload('<script>alert(1)</script>'));
+    }
+
+    /**
+     * @return InputBag<string>
+     */
+    private function payload(string $review, string $rating = '4'): InputBag
+    {
+        /** @var InputBag<string> $payload */
+        $payload = new InputBag(['rating' => $rating, 'review' => $review]);
+
+        return $payload;
+    }
+}

--- a/tests/Marketplace/PackageImageUploaderTest.php
+++ b/tests/Marketplace/PackageImageUploaderTest.php
@@ -35,7 +35,7 @@ final class PackageImageUploaderTest extends KernelTestCase
 
     public function testUploadsBannerAndReturnsBucketRelativePath(): void
     {
-        $zipPath = $this->makeZip(['banner.png' => 'png-bytes']);
+        $zipPath = $this->makeZip(['banner.png' => $this->imageBytes('png')]);
 
         $result = $this->uploader->uploadBannerFromZip('testuser/test-campaign', $zipPath);
 
@@ -44,7 +44,7 @@ final class PackageImageUploaderTest extends KernelTestCase
 
     public function testPicksJpegBannerExtension(): void
     {
-        $zipPath = $this->makeZip(['banner.jpg' => 'jpg-bytes']);
+        $zipPath = $this->makeZip(['banner.jpg' => $this->imageBytes('jpg')]);
 
         $result = $this->uploader->uploadBannerFromZip('vendor/with-jpeg', $zipPath);
 
@@ -60,7 +60,7 @@ final class PackageImageUploaderTest extends KernelTestCase
 
     public function testReadsBannerFromAssetsDirectory(): void
     {
-        $zipPath = $this->makeZip(['assets/banner.png' => 'png-bytes']);
+        $zipPath = $this->makeZip(['assets/banner.png' => $this->imageBytes('png')]);
 
         $result = $this->uploader->uploadBannerFromZip('testuser/assets-banner', $zipPath);
 
@@ -70,9 +70,9 @@ final class PackageImageUploaderTest extends KernelTestCase
     public function testUploadsGalleryImagesWithAltTextsFromAssetsDirectory(): void
     {
         $zipPath = $this->makeZip([
-            'assets/gallery/image_1.png' => 'png-bytes',
+            'assets/gallery/image_1.png' => $this->imageBytes('png'),
             'assets/gallery/image_1.alt.txt' => 'First screenshot',
-            'assets/gallery/image_2.jpg' => 'jpg-bytes',
+            'assets/gallery/image_2.jpg' => $this->imageBytes('jpg'),
         ]);
 
         $gallery = $this->uploader->uploadGalleryFromZip('testuser/with-gallery', $zipPath);
@@ -86,9 +86,9 @@ final class PackageImageUploaderTest extends KernelTestCase
     public function testReadsGalleryFromLegacyZipRoot(): void
     {
         $zipPath = $this->makeZip([
-            'gallery/image_1.png' => 'png-bytes',
+            'gallery/image_1.png' => $this->imageBytes('png'),
             'gallery/image_1.alt.txt' => 'Legacy layout',
-            'gallery/image_2.jpg' => 'jpg-bytes',
+            'gallery/image_2.jpg' => $this->imageBytes('jpg'),
         ]);
 
         $gallery = $this->uploader->uploadGalleryFromZip('testuser/legacy-gallery', $zipPath);
@@ -101,9 +101,71 @@ final class PackageImageUploaderTest extends KernelTestCase
 
     public function testReturnsEmptyGalleryWhenArchiveHasNoGalleryImages(): void
     {
-        $zipPath = $this->makeZip(['composer.json' => '{}', 'banner.png' => 'png-bytes']);
+        $zipPath = $this->makeZip(['composer.json' => '{}', 'banner.png' => $this->imageBytes('png')]);
 
         self::assertSame([], $this->uploader->uploadGalleryFromZip('testuser/no-gallery', $zipPath));
+    }
+
+    public function testSkipsBannerWithBombDimensions(): void
+    {
+        $zipPath = $this->makeZip(['banner.png' => $this->oversizedImageHeader()]);
+
+        self::assertNull($this->uploader->uploadBannerFromZip('testuser/bomb-banner', $zipPath));
+    }
+
+    public function testSkipsGalleryImageWithBombDimensionsButKeepsTheRest(): void
+    {
+        $zipPath = $this->makeZip([
+            'assets/gallery/image_1.png' => $this->oversizedImageHeader(),
+            'assets/gallery/image_2.png' => $this->imageBytes('png'),
+        ]);
+
+        $gallery = $this->uploader->uploadGalleryFromZip('testuser/mixed-gallery', $zipPath);
+
+        self::assertSame([
+            ['url' => 'package-media/testuser/mixed-gallery/gallery/2.png', 'alt' => ''],
+        ], $gallery);
+    }
+
+    public function testSkipsEntriesThatAreNotImagesAtAll(): void
+    {
+        $zipPath = $this->makeZip(['banner.png' => '<?php echo "not an image";']);
+
+        self::assertNull($this->uploader->uploadBannerFromZip('testuser/fake-banner', $zipPath));
+    }
+
+    /**
+     * The uploader reads every image's header now, so placeholder strings no longer pass.
+     */
+    private function imageBytes(string $format = 'png', int $width = 4, int $height = 4): string
+    {
+        $image = imagecreatetruecolor($width, $height);
+        self::assertNotFalse($image);
+
+        ob_start();
+        match ($format) {
+            'jpg' => imagejpeg($image),
+            'gif' => imagegif($image),
+            'webp' => imagewebp($image),
+            default => imagepng($image),
+        };
+        $bytes = ob_get_clean();
+
+        imagedestroy($image);
+        self::assertIsString($bytes);
+
+        return $bytes;
+    }
+
+    /**
+     * A PNG header claiming huge dimensions with no pixel data behind it — a decompression bomb,
+     * and small enough to slip under the byte limit.
+     */
+    private function oversizedImageHeader(int $width = 100_000, int $height = 100_000): string
+    {
+        $ihdr = 'IHDR'.pack('N2', $width, $height)."\x08\x02\x00\x00\x00";
+
+        return "\x89PNG\r\n\x1a\n".pack('N', 13).$ihdr.pack('N', crc32($ihdr));
     }
 
     /**

--- a/tests/Marketplace/PackageImageUploaderTest.php
+++ b/tests/Marketplace/PackageImageUploaderTest.php
@@ -136,25 +136,20 @@ final class PackageImageUploaderTest extends KernelTestCase
 
     /**
      * The uploader reads every image's header now, so placeholder strings no longer pass.
+     *
+     * These are 1x1 files kept as literals rather than generated, so the suite doesn't depend on
+     * ext-gd being installed.
      */
-    private function imageBytes(string $format = 'png', int $width = 4, int $height = 4): string
+    private function imageBytes(string $format = 'png'): string
     {
-        $image = imagecreatetruecolor($width, $height);
-        self::assertNotFalse($image);
-
-        ob_start();
-        match ($format) {
-            'jpg' => imagejpeg($image),
-            'gif' => imagegif($image),
-            'webp' => imagewebp($image),
-            default => imagepng($image),
+        $encoded = match ($format) {
+            'jpg' => '/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIs'
+                .'IxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAABAAEBAREA/8QAFAABAAAAAAAAAAAAAAAAAAAACf/EABQQAQAA'
+                .'AAAAAAAAAAAAAAAAAAD/2gAIAQEAAD8AKp//2Q==',
+            default => 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
         };
-        $bytes = ob_get_clean();
 
-        imagedestroy($image);
-        self::assertIsString($bytes);
-
-        return $bytes;
+        return (string) base64_decode($encoded, true);
     }
 
     /**


### PR DESCRIPTION
### Add a CSP, sanitise reviews and bound image uploads

Responses carry a Content-Security-Policy built around a per-request nonce; the import map and its entrypoint are the only inline scripts. style-src keeps 'unsafe-inline' because the Carbon components compute custom properties per element.

Review text loses its tags before the length check, so markup cannot pad a review up to the minimum.

Image uploads are capped at 25 megapixels read from the header, since a decompression bomb stays under the 5MB limit while decoding to billions of pixels.

Render upload size limits from the PHP constants

Upload size limits are rendered onto data attributes rather than duplicated in JavaScript, so PackageZipUploader::MAX_BYTES and PackageImageUploader::MAX_BYTES stay the single source of truth. A data attribute rather than an inline script keeps this from needing a CSP exception.

Add a public registry API for Mautic instances

Mautic instances read the marketplace through a versioned public registry API instead of calling Supabase directly, which is what let the anon key be dropped from every Mautic install. The routes sit outside /api/package on purpose, since that prefix is gated behind ROLE_USER.

Stop disclosing PHP and nginx versions in response headers

expose_php is off in the image and ServerTokens/ServerSignature are trimmed in apache2.conf. The deploy script writes server_tokens off; and proxy_hide_header X-Powered-By; at http level, so it covers both the prod and staging server blocks and survives the site config being regenerated on each deploy.

Addresses findings from the Radically Open Security penetration test (v1.0, July 2026).